### PR TITLE
fix flaky user list test in rails

### DIFF
--- a/backend/celeryapp/spec/requests/users_spec.rb
+++ b/backend/celeryapp/spec/requests/users_spec.rb
@@ -91,6 +91,9 @@ RSpec.describe "User", type: :request do
 
   describe "GET /users/[:id]" do
     before(:context) do
+      # users created in before(:contexts) may persist
+      User.destroy_all
+
       @my_user = create(:user)
 
       headers = { 'ACCEPT' => 'application/json' }


### PR DESCRIPTION
# feature

Test was flaky because there were a bunch of users persisting in the test db.

I thought I had it configured such that the test db would be cleared between runs.  But it looks like [data created in before(:context) persists](https://rspec.info/features/6-1/rspec-rails/Transactions/).  So I'm going to explictly destroy all of the created users before the test run.