### PR TITLE
Display comments and post comments on individual recommendations, events, and posts

### DIFF
--- a/backend/celeryapp/app/controllers/events_controller.rb
+++ b/backend/celeryapp/app/controllers/events_controller.rb
@@ -24,7 +24,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @event = Event.find_by(id: params[:id])
+    @event = Event.includes(:comments).by_friends(current_user.friend_ids).find_by(id: params[:id])
     # TODO: PERMISSIONS
     if @event
       status = @event.rsvp_status_for_current_user(current_user)

--- a/backend/celeryapp/app/controllers/friendships_controller.rb
+++ b/backend/celeryapp/app/controllers/friendships_controller.rb
@@ -22,4 +22,12 @@ class FriendshipsController < ApplicationController
     render json: user.public_attributes, status: :created
     # TODO Error handling maybe?
   end
+
+  # This is to create a map of { id: friend } for quick lookup
+  def friends_map
+    friends_m = current_user.friends.each_with_object({}) do |friend, h|
+      h[friend.id] = friend.public_attributes
+    end
+    render json: friends_m, status: :ok
+  end
 end

--- a/backend/celeryapp/app/controllers/friendships_controller.rb
+++ b/backend/celeryapp/app/controllers/friendships_controller.rb
@@ -25,7 +25,7 @@ class FriendshipsController < ApplicationController
 
   # This is to create a map of { id: friend } for quick lookup
   def friends_map
-    friends_m = (current_user.friends << current_user).each_with_object({}) do |friend, h|
+    friends_m = (current_user.friends.to_a << current_user).each_with_object({}) do |friend, h|
       h[friend.id] = friend.public_attributes
     end
     render json: friends_m, status: :ok

--- a/backend/celeryapp/app/controllers/friendships_controller.rb
+++ b/backend/celeryapp/app/controllers/friendships_controller.rb
@@ -25,7 +25,7 @@ class FriendshipsController < ApplicationController
 
   # This is to create a map of { id: friend } for quick lookup
   def friends_map
-    friends_m = current_user.friends.each_with_object({}) do |friend, h|
+    friends_m = (current_user.friends << current_user).each_with_object({}) do |friend, h|
       h[friend.id] = friend.public_attributes
     end
     render json: friends_m, status: :ok

--- a/backend/celeryapp/app/controllers/posts_controller.rb
+++ b/backend/celeryapp/app/controllers/posts_controller.rb
@@ -22,11 +22,11 @@ class PostsController < ApplicationController
 
   def show
     post_id = params[:id]
-    @post = Post.find_by(id: post_id)
+    @post = Post.includes(:comments).by_friends(current_user.friend_ids).find_by(id: post_id)
     if @post
       render json: @post.attributes, status: :ok
     else
-      render json: { error: "post not found" }, status: :unprocessable_content
+      render json: { error: "post not found" }, status: :not_found
     end
 
   end

--- a/backend/celeryapp/app/controllers/posts_controller.rb
+++ b/backend/celeryapp/app/controllers/posts_controller.rb
@@ -4,9 +4,9 @@ class PostsController < ApplicationController
     user_id = params[:user_id]
     posts = Post.by_friends(friend_ids).order(created_at: :desc)
     posts = posts.where(user_id: user_id) if user_id
-    recommendations = Recommendation.all.order(created_at: :desc)
+    recommendations = Recommendation.by_friends(friend_ids).order(created_at: :desc)
     recommendations = recommendations.where(user_id: user_id) if user_id
-    events = Event.all.includes(:rsvps).order(created_at: :desc)
+    events = Event.by_friends(friend_ids).includes(:rsvps).order(created_at: :desc)
     events = events.where(user_id: user_id) if user_id
     feed = merge_by_time(posts, recommendations)
     feed = merge_by_time(feed, events)

--- a/backend/celeryapp/app/controllers/posts_controller.rb
+++ b/backend/celeryapp/app/controllers/posts_controller.rb
@@ -1,7 +1,8 @@
 class PostsController < ApplicationController
   def index
+    friend_ids = current_user.friend_ids
     user_id = params[:user_id]
-    posts = Post.all.order(created_at: :desc)
+    posts = Post.by_friends(friend_ids).order(created_at: :desc)
     posts = posts.where(user_id: user_id) if user_id
     recommendations = Recommendation.all.order(created_at: :desc)
     recommendations = recommendations.where(user_id: user_id) if user_id

--- a/backend/celeryapp/app/controllers/posts_controller.rb
+++ b/backend/celeryapp/app/controllers/posts_controller.rb
@@ -2,11 +2,11 @@ class PostsController < ApplicationController
   def index
     friend_ids = current_user.friend_ids
     user_id = params[:user_id]
-    posts = Post.by_friends(friend_ids).order(created_at: :desc)
+    posts = Post.includes(:comments).by_friends(friend_ids).order(created_at: :desc)
     posts = posts.where(user_id: user_id) if user_id
-    recommendations = Recommendation.by_friends(friend_ids).order(created_at: :desc)
+    recommendations = Recommendation.includes(:comments).by_friends(friend_ids).order(created_at: :desc)
     recommendations = recommendations.where(user_id: user_id) if user_id
-    events = Event.by_friends(friend_ids).includes(:rsvps).order(created_at: :desc)
+    events = Event.includes(:comments, :rsvps).by_friends(friend_ids).order(created_at: :desc)
     events = events.where(user_id: user_id) if user_id
     feed = merge_by_time(posts, recommendations)
     feed = merge_by_time(feed, events)

--- a/backend/celeryapp/app/controllers/recommendations_controller.rb
+++ b/backend/celeryapp/app/controllers/recommendations_controller.rb
@@ -15,9 +15,9 @@ class RecommendationsController < ApplicationController
   end
 
   def show
-    @recommendation = Recommendation.find_by(id: params[:id])
+    @recommendation = Recommendation.includes(:comments).by_friends(current_user.friend_ids).find_by(id: params[:id])
     if @recommendation.nil?
-      render json: {}, status: :not_found and return
+      render json: { error: 'not found' }, status: :not_found and return
     end
     # TODO permissions
     render json: @recommendation.attributes, status: :ok

--- a/backend/celeryapp/app/models/event.rb
+++ b/backend/celeryapp/app/models/event.rb
@@ -10,7 +10,7 @@ class Event < ApplicationRecord
   validates :start_date_time, presence: true
 
   scope :by_friends, ->(friend_ids) { where(user_id: friend_ids) }
-  
+
   def rsvp_status_for_current_user(current_user)
     self.rsvps.where(user_id: current_user.id).first&.status
   end
@@ -38,13 +38,13 @@ class Event < ApplicationRecord
         ON events.id = r.event_id
 "
     )
-    debugger
   end
 
   def total_rsvp
     self.rsvps.count
   end
 
+  # TODO: limit # of comments
   def attributes
     super.merge({
                   user: user.public_attributes,
@@ -56,6 +56,7 @@ class Event < ApplicationRecord
                   create_date_string: get_date_string(created_at),
                   create_time_string: get_time_string(created_at),
                   rsvps_count: total_rsvp,
+                  comments: comments,
                 }
     )
   end

--- a/backend/celeryapp/app/models/event.rb
+++ b/backend/celeryapp/app/models/event.rb
@@ -9,6 +9,8 @@ class Event < ApplicationRecord
   validates :title, presence: true
   validates :start_date_time, presence: true
 
+  scope :by_friends, ->(friend_ids) { where(user_id: friend_ids) }
+  
   def rsvp_status_for_current_user(current_user)
     self.rsvps.where(user_id: current_user.id).first&.status
   end

--- a/backend/celeryapp/app/models/post.rb
+++ b/backend/celeryapp/app/models/post.rb
@@ -10,6 +10,8 @@ class Post < ApplicationRecord
 
   validates :post_title, presence: true
 
+  scope :by_friends, ->(friend_ids) { where(user_id: friend_ids) }
+
   def attributes
     super.merge(
       { recommendations: recommendations,

--- a/backend/celeryapp/app/models/post.rb
+++ b/backend/celeryapp/app/models/post.rb
@@ -21,6 +21,7 @@ class Post < ApplicationRecord
         create_time_string: get_time_string(created_at),
         creator_id: user.id,
         creator_name: user.name,
+        comments: comments,
       })
   end
 

--- a/backend/celeryapp/app/models/recommendation.rb
+++ b/backend/celeryapp/app/models/recommendation.rb
@@ -9,6 +9,8 @@ class Recommendation < ApplicationRecord
 
   validates :title, presence: true
 
+  scope :by_friends, ->(friend_ids) { where(user_id: friend_ids) }
+
   def unrated?
     rating == 0 || rating.nil?
   end

--- a/backend/celeryapp/app/models/recommendation.rb
+++ b/backend/celeryapp/app/models/recommendation.rb
@@ -23,6 +23,7 @@ class Recommendation < ApplicationRecord
                   create_time_string: get_time_string(created_at),
                   creator_id: user.id,
                   creator_name: user.name,
+                  comments: comments,
                 })
   end
 end

--- a/backend/celeryapp/app/models/user.rb
+++ b/backend/celeryapp/app/models/user.rb
@@ -39,6 +39,11 @@ class User < ApplicationRecord
     sessions.where.not(id: Current.session).delete_all
   end
 
+  # friends and myself
+  def friend_ids
+    friends.pluck(:friend_id) << id
+  end
+
   def active_notifications
     self.notifications.where('active = true').order(created_at: :desc)
   end

--- a/backend/celeryapp/config/routes.rb
+++ b/backend/celeryapp/config/routes.rb
@@ -19,7 +19,11 @@ Rails.application.routes.draw do
   resources :posts
   resources :rsvps
   resources :users, only: [:index, :show, :update]
-  resources :friendships
+  resources :friendships do
+    collection do
+      get 'friends_map'
+    end
+  end
   resources :friend_requests
   resources :notifications
   resources :comments

--- a/backend/celeryapp/spec/requests/events_spec.rb
+++ b/backend/celeryapp/spec/requests/events_spec.rb
@@ -135,10 +135,13 @@ RSpec.describe "Events", type: :request do
 
       auth_token = JSON.parse(response.body)["auth_token"]
       @headers = { 'ACCEPT' => 'application/json', 'Authorization' => "Token #{auth_token}" }
+
+      @friend = create(:user)
+      Friendship.create_bidirectional_friendship!(@my_user, @friend)
     end
 
     it 'gets a specific event' do
-      event = create(:event)
+      event = create(:event, user: @my_user)
 
       get "/events/#{event.id}", headers: @headers
 
@@ -150,7 +153,7 @@ RSpec.describe "Events", type: :request do
     end
 
     it 'gets an event with rsvps' do
-      event = create(:event)
+      event = create(:event, user: @friend)
       create(:rsvp, user: @my_user, event: event)
 
       get "/events/#{event.id}", headers: @headers

--- a/backend/celeryapp/spec/requests/friendships_spec.rb
+++ b/backend/celeryapp/spec/requests/friendships_spec.rb
@@ -91,4 +91,32 @@ RSpec.describe "Friendships", type: :request do
 
   end
 
+  describe "GET /friends_map" do
+    before(:context) do
+      @my_user = create(:user)
+
+      headers = { 'ACCEPT' => 'application/json' }
+      post "/sign_in", params: { email: @my_user.email, password: @my_user.password }, headers: headers
+
+      auth_token = JSON.parse(response.body)["auth_token"]
+      @headers = { 'ACCEPT' => 'application/json', 'Authorization' => "Token #{auth_token}" }
+    end
+
+    it 'lists my friends' do
+      friend = create(:user)
+      friend2 = create(:user)
+      friend3 = create(:user)
+      Friendship.create_bidirectional_friendship!(@my_user, friend)
+      Friendship.create_bidirectional_friendship!(@my_user, friend2)
+      Friendship.create_bidirectional_friendship!(@my_user, friend3)
+
+      get '/friendships/friends_map', headers: @headers
+
+      expect(response).to have_http_status(:ok)
+      res = JSON.parse(response.body)
+      expect(res.size).to eq(3)
+      expect(res.values.first).to include("name")
+    end
+  end
+
 end

--- a/backend/celeryapp/spec/requests/friendships_spec.rb
+++ b/backend/celeryapp/spec/requests/friendships_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Friendships", type: :request do
 
       expect(response).to have_http_status(:ok)
       res = JSON.parse(response.body)
-      expect(res.size).to eq(3)
+      expect(res.size).to eq(4)
       expect(res.values.first).to include("name")
     end
   end

--- a/backend/celeryapp/spec/requests/posts_spec.rb
+++ b/backend/celeryapp/spec/requests/posts_spec.rb
@@ -129,8 +129,7 @@ RSpec.describe "Posts", type: :request do
     end
 
     it 'gets events' do
-      user = create(:user)
-      create(:event, user: user)
+      create(:event, user: @friend)
       create(:event, user: @my_user)
 
       get "/posts", params: {}, headers: @headers

--- a/backend/celeryapp/spec/requests/posts_spec.rb
+++ b/backend/celeryapp/spec/requests/posts_spec.rb
@@ -74,11 +74,14 @@ RSpec.describe "Posts", type: :request do
 
       auth_token = JSON.parse(response.body)["auth_token"]
       @headers = { 'ACCEPT' => 'application/json', 'Authorization' => "Token #{auth_token}" }
+
+      @friend = create(:user)
+      Friendship.create_bidirectional_friendship!(@my_user, @friend)
     end
 
     it 'gets all posts' do
       3.times do
-        create(:post)
+        create(:post, user: @friend)
       end
       get "/posts", params: {}, headers: @headers
 
@@ -91,9 +94,8 @@ RSpec.describe "Posts", type: :request do
     end
 
     it 'gets all posts and recommendations' do
-      user = create(:user)
-      create(:post, user: user)
-      create(:recommendation, user: user)
+      create(:post, user: @friend)
+      create(:recommendation, user: @friend)
       create(:post, user: @my_user)
 
       get "/posts", params: {}, headers: @headers
@@ -109,10 +111,9 @@ RSpec.describe "Posts", type: :request do
     end
 
     it 'gets all posts, recommendations, and events' do
-      user = create(:user)
-      create(:post, user: user)
-      create(:recommendation, user: user)
-      create(:event, user: user)
+      create(:post, user: @friend)
+      create(:recommendation, user: @friend)
+      create(:event, user: @friend)
       create(:post, user: @my_user)
 
       get "/posts", params: {}, headers: @headers

--- a/backend/celeryapp/spec/requests/posts_spec.rb
+++ b/backend/celeryapp/spec/requests/posts_spec.rb
@@ -149,6 +149,20 @@ RSpec.describe "Posts", type: :request do
       expect(res[0]['class_name']).to eq('Event')
     end
 
+    it 'gets posts with comments' do
+      post1 = create(:post, user: @friend)
+      create(:comment, :for_post, commentable: post1, user: @my_user)
+      create(:comment, :for_post, commentable: post1, user: @friend)
+
+      get "/posts", params: {}, headers: @headers
+
+      expect(response).to have_http_status(:ok)
+      res = JSON.parse(response.body)
+      expect(res.size).to eq(1)
+      expect(res[0]['comments'].size).to eq(2)
+      expect(res[0]['comments'][0]['body']).to_not be_nil
+    end
+
   end
 
   describe "GET /posts/:id" do

--- a/backend/celeryapp/spec/requests/recommendations_spec.rb
+++ b/backend/celeryapp/spec/requests/recommendations_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe "Recommendations", type: :request do
       expect(res['title']).to eq(recommendation.title)
     end
 
+    it 'will not get the recommendation if not by my friend' do
+      recommendation = create(:recommendation)
+
+      get "/recommendations/#{recommendation.id}", headers: @headers
+
+      expect(response).to have_http_status(:not_found)
+      res = JSON.parse(response.body)
+      expect(res['error']).to eq('not found')
+    end
+
     it 'fails if the recommendation does not exist' do
       create(:recommendation, user: @my_user)
 

--- a/web/components.json
+++ b/web/components.json
@@ -1,14 +1,15 @@
 {
-	"$schema": "https://shadcn-svelte.com/schema.json",
-	"style": "default",
-	"tailwind": {
-		"config": "tailwind.config.js",
-		"css": "src/app.css",
-		"baseColor": "slate"
-	},
-	"aliases": {
-		"components": "$lib/components",
-		"utils": "$lib/utils"
-	},
-	"typescript": true
+  "$schema": "https://shadcn-svelte.com/schema.json",
+  "style": "default",
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/app.css",
+    "baseColor": "slate",
+    "cssVariables": false
+  },
+  "aliases": {
+    "components": "$lib/components",
+    "utils": "$lib/utils"
+  },
+  "typescript": true
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "web",
 			"version": "0.0.1",
 			"dependencies": {
+				"@lucide/svelte": "^0.503.0",
 				"@tailwindcss/vite": "^4.0.8",
 				"moment": "^2.30.1",
 				"tailwindcss": "^4.0.8"
@@ -33,7 +34,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -495,7 +495,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
 			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -510,7 +509,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -520,7 +518,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -530,18 +527,25 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
 			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@lucide/svelte": {
+			"version": "0.503.0",
+			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-0.503.0.tgz",
+			"integrity": "sha512-Y7Q8pHnX2YG8Ef4a/VnYFN9tTAJS33MiS78vQtPiyp5iiWuBlTMoViMiRUxQb7U9Ro46RdJ0kpCADvvha3Z2rA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"svelte": "^5"
 			}
 		},
 		"node_modules/@neoconfetti/svelte": {
@@ -921,7 +925,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
 			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8.9.0"
@@ -957,9 +960,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.20.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.5.tgz",
-			"integrity": "sha512-zT/97KvVUo19jEGZa972ls7KICjPCB53j54TVxnEFT5VEwL16G+YFqRVwJbfxh7AmS7/Ptr1rKF7Qt4FBMDNlw==",
+			"version": "2.20.7",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.20.7.tgz",
+			"integrity": "sha512-dVbLMubpJJSLI4OYB+yWYNHGAhgc2bVevWuBjDj8jFUXIJOAnLwYP3vsmtcgoxNGUXoq0rHS5f7MFCsryb6nzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1285,7 +1288,6 @@
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
 			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1298,7 +1300,6 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
 			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -1308,7 +1309,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
 			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -1389,7 +1389,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -1523,14 +1522,12 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
 			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
 			"version": "1.4.6",
 			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
 			"integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -1544,10 +1541,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-			"dev": true,
+			"version": "6.4.4",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+			"integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
@@ -1906,14 +1902,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
 			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
@@ -1990,7 +1984,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -2162,7 +2155,6 @@
 			"version": "5.25.10",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.25.10.tgz",
 			"integrity": "sha512-tOUlvm3goAhmELYKWYX3SchYeqlVlIcUfKA4qIgd6Urm7qDw3KiZP/wJtoRv3ZeRUHPorM9f6+lOlbFxUN8QoA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
@@ -2212,7 +2204,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
 			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
@@ -2279,6 +2270,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+			"integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -2311,14 +2318,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-			"integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
+			"integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
+				"fdir": "^6.4.3",
+				"picomatch": "^4.0.2",
 				"postcss": "^8.5.3",
-				"rollup": "^4.30.1"
+				"rollup": "^4.34.9",
+				"tinyglobby": "^0.2.12"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -2404,7 +2414,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
 			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-			"dev": true,
 			"license": "MIT"
 		}
 	}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
 				"@sveltejs/adapter-node": "^5.2.12",
 				"@sveltejs/kit": "^2.16.0",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
+				"bits-ui": "^0.22.0",
 				"clsx": "^2.1.1",
 				"svelte": "^5.3.0",
 				"svelte-check": "^4.0.0",
@@ -442,6 +443,34 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+			"integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.9"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.13",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+			"integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.9"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@fontsource/fira-mono": {
 			"version": "5.2.5",
 			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-5.2.5.tgz",
@@ -450,6 +479,16 @@
 			"license": "OFL-1.1",
 			"funding": {
 				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@internationalized/date": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+			"integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -988,6 +1027,16 @@
 				"vite": "^6.0.0"
 			}
 		},
+		"node_modules/@swc/helpers": {
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+			"integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
+		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.3.tgz",
@@ -1265,6 +1314,61 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/bits-ui": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-0.22.0.tgz",
+			"integrity": "sha512-r7Fw1HNgA4YxZBRcozl7oP0bheQ8EHh+kfMBZJgyFISix8t4p/nqDcHLmBgIiJ3T5XjYnJRorYDjIWaCfhb5fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@internationalized/date": "^3.5.1",
+				"@melt-ui/svelte": "0.76.2",
+				"nanoid": "^5.0.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/huntabyte"
+			},
+			"peerDependencies": {
+				"svelte": "^4.0.0 || ^5.0.0"
+			}
+		},
+		"node_modules/bits-ui/node_modules/@melt-ui/svelte": {
+			"version": "0.76.2",
+			"resolved": "https://registry.npmjs.org/@melt-ui/svelte/-/svelte-0.76.2.tgz",
+			"integrity": "sha512-7SbOa11tXUS95T3fReL+dwDs5FyJtCEqrqG3inRziDws346SYLsxOQ6HmX+4BkIsQh1R8U3XNa+EMmdMt38lMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.3.1",
+				"@floating-ui/dom": "^1.4.5",
+				"@internationalized/date": "^3.5.0",
+				"dequal": "^2.0.3",
+				"focus-trap": "^7.5.2",
+				"nanoid": "^5.0.4"
+			},
+			"peerDependencies": {
+				"svelte": ">=3 <5"
+			}
+		},
+		"node_modules/bits-ui/node_modules/nanoid": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.js"
+			},
+			"engines": {
+				"node": "^18 || >=20"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1334,6 +1438,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -1442,6 +1556,16 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/focus-trap": {
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+			"integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tabbable": "^6.2.0"
 			}
 		},
 		"node_modules/fsevents": {
@@ -2094,6 +2218,13 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/tabbable": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tailwind-merge": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
@@ -2157,6 +2288,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/typescript": {
 			"version": "5.8.3",

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
 		"@sveltejs/adapter-node": "^5.2.12",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"bits-ui": "^0.22.0",
 		"clsx": "^2.1.1",
 		"svelte": "^5.3.0",
 		"svelte-check": "^4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
 		"vite": "^6.0.0"
 	},
 	"dependencies": {
+		"@lucide/svelte": "^0.503.0",
 		"@tailwindcss/vite": "^4.0.8",
 		"moment": "^2.30.1",
 		"tailwindcss": "^4.0.8"

--- a/web/src/lib/components/posts/Comment.svelte
+++ b/web/src/lib/components/posts/Comment.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
     import {friends_map} from "$lib/state/friends_map.svelte";
-    import {rails_date_pretty, rails_datetime_pretty} from "$lib/utils/dates.svelte";
+    import {rails_datetime_pretty} from "$lib/utils/dates.svelte";
 
     const {comment} = $props();
     const author = $derived(friends_map.friends_map[comment.user_id] ?? {});
 </script>
-{console.log(comment.user_id)}
-{console.log(author)}
 
 <div class="flex justify-left">
     <article class="p-6 text-base bg-white rounded-lg dark:bg-gray-900">

--- a/web/src/lib/components/posts/Comment.svelte
+++ b/web/src/lib/components/posts/Comment.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
     import {friends_map} from "$lib/state/friends_map.svelte";
     import {rails_datetime_pretty} from "$lib/utils/dates.svelte";
+    import Link from '$lib/components/text/Link.svelte';
 
     const {comment} = $props();
     const author = $derived(friends_map.friends_map[comment.user_id] ?? {});
 </script>
 
 <div class="flex justify-left">
-    <article class="p-6 text-base bg-white rounded-lg dark:bg-gray-900">
-        <div class="flex justify-between items-center mb-2">
+    <article class="p-2 text-base bg-white rounded-lg dark:bg-gray-900">
+        <div class="flex justify-between items-center ">
             <div class="flex items-center">
                 <p class="inline-flex items-center mr-3 text-sm text-gray-900 dark:text-white font-semibold">
-                    {author.name}
+                    <Link url="/users/{comment.user_id}">{author.name}</Link>
                 </p>
                 <p class="text-sm text-gray-600 dark:text-gray-400">
                     {rails_datetime_pretty(comment.created_at)}

--- a/web/src/lib/components/posts/Comment.svelte
+++ b/web/src/lib/components/posts/Comment.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import {friends_map} from "$lib/state/friends_map.svelte";
+    import {rails_date_pretty, rails_datetime_pretty} from "$lib/utils/dates.svelte";
+
+    const {comment} = $props();
+    const author = $derived(friends_map.friends_map[comment.user_id] ?? {});
+</script>
+{console.log(comment.user_id)}
+{console.log(author)}
+
+<div class="flex justify-left">
+    <article class="p-6 text-base bg-white rounded-lg dark:bg-gray-900">
+        <div class="flex justify-between items-center mb-2">
+            <div class="flex items-center">
+                <p class="inline-flex items-center mr-3 text-sm text-gray-900 dark:text-white font-semibold">
+                    {author.name}
+                </p>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                    {rails_datetime_pretty(comment.created_at)}
+                </p>
+            </div>
+        </div>
+        <div class="text-left">
+            <p class="text-gray-500 dark:text-gray-400">
+                {comment.body}
+            </p>
+        </div>
+    </article>
+</div>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -6,6 +6,8 @@
     import PostCard from "$lib/components/posts/PostCard.svelte";
     import EventCard from "$lib/components/posts/EventCard.svelte";
 
+    import * as Collapsible from "$lib/components/ui/collapsible";
+
     let {feed_item} = $props();
 
     let by_line = ' posted';
@@ -22,18 +24,26 @@
     //TODO: different component based on which type
 
 
-
 </script>
 <div class="p-2 my-2 border-bottom-2 border-gray-600 rounded-lg shadow-md">
-    {#if feed_item.class_name === 'Recommendation'}
-        <RecommendationCard feed_item={feed_item} />
+    <Collapsible.Root>
+        {#if feed_item.class_name === 'Recommendation'}
+            <RecommendationCard feed_item={feed_item}/>
         {:else if feed_item.class_name === 'Post'}
-                <PostCard feed_item={feed_item} />
+            <PostCard feed_item={feed_item}/>
 
-            {:else}
-        <div>
+        {:else}
+            <div>
 
-        <EventCard feed_item={feed_item} />
-        </div>
+                <EventCard feed_item={feed_item}/>
+            </div>
         {/if}
-    </div>
+        <Collapsible.Trigger>
+            Comments
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+            I had some thoughts about this
+        </Collapsible.Content>
+
+    </Collapsible.Root>
+</div>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -7,6 +7,7 @@
     import EventCard from "$lib/components/posts/EventCard.svelte";
 
     import * as Collapsible from "$lib/components/ui/collapsible";
+    import {MessageCircleMore} from '@lucide/svelte';
 
     let {feed_item} = $props();
 
@@ -39,7 +40,14 @@
             </div>
         {/if}
         <Collapsible.Trigger>
-            Comments
+
+            <Link>
+                <div class="flex">
+                    Comments
+                    <MessageCircleMore/>
+                </div>
+
+            </Link>
         </Collapsible.Trigger>
         <Collapsible.Content>
             I had some thoughts about this

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -46,11 +46,7 @@
                 <EventCard feed_item={feed_item}/>
             </div>
         {/if}
-        <div>
-            {#if feed_item.comments.length > 0}
-                <p>{friends_map.friends_map[feed_item.user_id].name}: {feed_item.comments[0].body}</p>
-            {/if}
-        </div>
+
         <Collapsible.Trigger>
 
             <Link>
@@ -60,6 +56,11 @@
                 </div>
 
             </Link>
+            <div>
+                {#if feed_item.comments.length > 0}
+                    <p>{friends_map.friends_map[feed_item.user_id].name}: {feed_item.comments[0].body}</p>
+                {/if}
+            </div>
         </Collapsible.Trigger>
         <Collapsible.Content>
             <div>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -55,7 +55,7 @@
         <Collapsible.Content>
             <form
                     method="POST"
-                    action="?/add_comment"
+                    action="?/submit_comment"
                     use:enhance={() => {
             posting = true;
             return async ({update}) => {
@@ -66,9 +66,9 @@
             >
                 <input type="hidden" name="commentable_id" value={feed_item.id}/>
                 <input type="hidden" name="commentable_type" value={feed_item.class_name}/>
-                <Textarea placeholder="I was thinking..."/>
+                <Textarea name="body" placeholder="I was thinking..."/>
                 <div class="flex justify-center pt-2">
-                    <Button className=" bg-lime-200 ">*~Submit Comment~*</Button>
+                    <Button type="submit" className=" bg-lime-200 ">*~Submit Comment~*</Button>
                 </div>
             </form>
         </Collapsible.Content>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -11,6 +11,8 @@
     import {Button} from "$lib/components/ui/button";
     import {MessageCircleMore} from '@lucide/svelte';
 
+    import {friends_map} from "$lib/state/friends_map.svelte";
+
     let {feed_item} = $props();
 
     let by_line = ' posted';
@@ -31,7 +33,6 @@
 
 
 </script>
-{console.log(feed_item['comments'])}
 <div class="p-2 my-2 border-bottom-2 border-gray-600 rounded-lg shadow-md">
     <Collapsible.Root>
         {#if feed_item.class_name === 'Recommendation'}
@@ -64,6 +65,7 @@
             <div>
                 <div>
                     {#each feed_item.comments as comment}
+                        <p>{friends_map.friends_map[comment.user_id] ?? 'not found'}</p>
                         <p>{comment.body}</p>
                     {/each}
                 </div>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -12,6 +12,7 @@
     import {MessageCircleMore} from '@lucide/svelte';
 
     import {friends_map} from "$lib/state/friends_map.svelte";
+    import Comment from "$lib/components/posts/Comment.svelte";
 
     let {feed_item} = $props();
 
@@ -58,7 +59,8 @@
             </Link>
             <div>
                 {#if feed_item.comments.length > 0}
-                    <p>{friends_map.friends_map[feed_item.user_id].name}: {feed_item.comments[0].body}</p>
+                    <!--                    <p>{friends_map.friends_map[feed_item.user_id].name}: {feed_item.comments[0].body}</p>-->
+                    <Comment comment={feed_item.comments[0]}/>
                 {/if}
             </div>
         </Collapsible.Trigger>
@@ -66,7 +68,8 @@
             <div>
                 <div>
                     {#each feed_item.comments.slice(1) as comment}
-                        <p>{friends_map.friends_map[feed_item.user_id].name}: {comment.body}</p>
+                        <!--                        <p>{friends_map.friends_map[feed_item.user_id].name}: {comment.body}</p>-->
+                        <Comment {comment}/>
                     {/each}
                 </div>
                 <form

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -11,7 +11,6 @@
     import {Button} from "$lib/components/ui/button";
     import {MessageCircleMore} from '@lucide/svelte';
 
-    import {friends_map} from "$lib/state/friends_map.svelte";
     import Comment from "$lib/components/posts/Comment.svelte";
 
     let {feed_item} = $props();
@@ -59,7 +58,6 @@
             </Link>
             <div>
                 {#if feed_item.comments.length > 0}
-                    <!--                    <p>{friends_map.friends_map[feed_item.user_id].name}: {feed_item.comments[0].body}</p>-->
                     <Comment comment={feed_item.comments[0]}/>
                 {/if}
             </div>
@@ -68,7 +66,6 @@
             <div>
                 <div>
                     {#each feed_item.comments.slice(1) as comment}
-                        <!--                        <p>{friends_map.friends_map[feed_item.user_id].name}: {comment.body}</p>-->
                         <Comment {comment}/>
                     {/each}
                 </div>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -48,7 +48,7 @@
         {/if}
         <div>
             {#if feed_item.comments.length > 0}
-                <p>{feed_item.comments[0].body}</p>
+                <p>{friends_map.friends_map[feed_item.user_id].name}: {feed_item.comments[0].body}</p>
             {/if}
         </div>
         <Collapsible.Trigger>
@@ -64,9 +64,8 @@
         <Collapsible.Content>
             <div>
                 <div>
-                    {#each feed_item.comments as comment}
-                        <p>{friends_map.friends_map[comment.user_id] ?? 'not found'}</p>
-                        <p>{comment.body}</p>
+                    {#each feed_item.comments.slice(1) as comment}
+                        <p>{friends_map.friends_map[feed_item.user_id].name}: {comment.body}</p>
                     {/each}
                 </div>
                 <form

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -12,6 +12,7 @@
     import {MessageCircleMore} from '@lucide/svelte';
 
     import Comment from "$lib/components/posts/Comment.svelte";
+    import SubmitComment from "$lib/components/posts/SubmitComment.svelte";
 
     let {feed_item} = $props();
 
@@ -69,24 +70,7 @@
                         <Comment {comment}/>
                     {/each}
                 </div>
-                <form
-                        method="POST"
-                        action="?/submit_comment"
-                        use:enhance={() => {
-            posting = true;
-            return async ({update}) => {
-                await update();
-                posting = false;
-            };
-        }}
-                >
-                    <input type="hidden" name="commentable_id" value={feed_item.id}/>
-                    <input type="hidden" name="commentable_type" value={feed_item.class_name}/>
-                    <Textarea name="body" placeholder="I was thinking..."/>
-                    <div class="flex justify-center pt-2">
-                        <Button type="submit" className=" bg-lime-200 ">*~Submit Comment~*</Button>
-                    </div>
-                </form>
+                <SubmitComment {feed_item}/>
             </div>
         </Collapsible.Content>
 

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -25,10 +25,13 @@
 
     let posting = $state(false);
 
+    const num_comments = feed_item['comments']?.length;
+
     //TODO: Style the shadcn Button component to be a fun color!!
 
 
 </script>
+{console.log(feed_item['comments'])}
 <div class="p-2 my-2 border-bottom-2 border-gray-600 rounded-lg shadow-md">
     <Collapsible.Root>
         {#if feed_item.class_name === 'Recommendation'}
@@ -42,35 +45,47 @@
                 <EventCard feed_item={feed_item}/>
             </div>
         {/if}
+        <div>
+            {#if feed_item.comments.length > 0}
+                <p>{feed_item.comments[0].body}</p>
+            {/if}
+        </div>
         <Collapsible.Trigger>
 
             <Link>
                 <div class="flex">
-                    Comments
+                    {num_comments} Comments
                     <MessageCircleMore/>
                 </div>
 
             </Link>
         </Collapsible.Trigger>
         <Collapsible.Content>
-            <form
-                    method="POST"
-                    action="?/submit_comment"
-                    use:enhance={() => {
+            <div>
+                <div>
+                    {#each feed_item.comments as comment}
+                        <p>{comment.body}</p>
+                    {/each}
+                </div>
+                <form
+                        method="POST"
+                        action="?/submit_comment"
+                        use:enhance={() => {
             posting = true;
             return async ({update}) => {
                 await update();
                 posting = false;
             };
         }}
-            >
-                <input type="hidden" name="commentable_id" value={feed_item.id}/>
-                <input type="hidden" name="commentable_type" value={feed_item.class_name}/>
-                <Textarea name="body" placeholder="I was thinking..."/>
-                <div class="flex justify-center pt-2">
-                    <Button type="submit" className=" bg-lime-200 ">*~Submit Comment~*</Button>
-                </div>
-            </form>
+                >
+                    <input type="hidden" name="commentable_id" value={feed_item.id}/>
+                    <input type="hidden" name="commentable_type" value={feed_item.class_name}/>
+                    <Textarea name="body" placeholder="I was thinking..."/>
+                    <div class="flex justify-center pt-2">
+                        <Button type="submit" className=" bg-lime-200 ">*~Submit Comment~*</Button>
+                    </div>
+                </form>
+            </div>
         </Collapsible.Content>
 
     </Collapsible.Root>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -7,6 +7,7 @@
     import EventCard from "$lib/components/posts/EventCard.svelte";
 
     import * as Collapsible from "$lib/components/ui/collapsible";
+    import {Textarea} from "$lib/components/ui/textarea";
     import {MessageCircleMore} from '@lucide/svelte';
 
     let {feed_item} = $props();
@@ -50,7 +51,7 @@
             </Link>
         </Collapsible.Trigger>
         <Collapsible.Content>
-            I had some thoughts about this
+            <Textarea placeholder="I was thinking..."/>
         </Collapsible.Content>
 
     </Collapsible.Root>

--- a/web/src/lib/components/posts/FeedItem.svelte
+++ b/web/src/lib/components/posts/FeedItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import Card from '$lib/components/Card.svelte';
+    import {enhance} from '$app/forms';
     import Link from '$lib/components/text/Link.svelte';
     import H2 from "$lib/components/text/H2.svelte";
     import RecommendationCard from "$lib/components/posts/RecommendationCard.svelte";
@@ -8,6 +8,7 @@
 
     import * as Collapsible from "$lib/components/ui/collapsible";
     import {Textarea} from "$lib/components/ui/textarea";
+    import {Button} from "$lib/components/ui/button";
     import {MessageCircleMore} from '@lucide/svelte';
 
     let {feed_item} = $props();
@@ -22,8 +23,9 @@
         border_color = "border-orange-500";
     }
 
+    let posting = $state(false);
 
-    //TODO: different component based on which type
+    //TODO: Style the shadcn Button component to be a fun color!!
 
 
 </script>
@@ -51,7 +53,24 @@
             </Link>
         </Collapsible.Trigger>
         <Collapsible.Content>
-            <Textarea placeholder="I was thinking..."/>
+            <form
+                    method="POST"
+                    action="?/add_comment"
+                    use:enhance={() => {
+            posting = true;
+            return async ({update}) => {
+                await update();
+                posting = false;
+            };
+        }}
+            >
+                <input type="hidden" name="commentable_id" value={feed_item.id}/>
+                <input type="hidden" name="commentable_type" value={feed_item.class_name}/>
+                <Textarea placeholder="I was thinking..."/>
+                <div class="flex justify-center pt-2">
+                    <Button className=" bg-lime-200 ">*~Submit Comment~*</Button>
+                </div>
+            </form>
         </Collapsible.Content>
 
     </Collapsible.Root>

--- a/web/src/lib/components/posts/SubmitComment.svelte
+++ b/web/src/lib/components/posts/SubmitComment.svelte
@@ -3,11 +3,11 @@
     import {Button} from "$lib/components/ui/button";
     import {Textarea} from "$lib/components/ui/textarea";
     import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
+    import {invalidateAll} from "$app/navigation";
 
     let {feed_item} = $props();
 
     let posting = $state(false);
-
 </script>
 
 <div class="mt-2">

--- a/web/src/lib/components/posts/SubmitComment.svelte
+++ b/web/src/lib/components/posts/SubmitComment.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+    import {enhance} from '$app/forms';
+    import {Button} from "$lib/components/ui/button";
+    import {Textarea} from "$lib/components/ui/textarea";
+    import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
+
+    let {feed_item} = $props();
+
+    let posting = $state(false);
+
+</script>
+
+<div class="mt-2">
+    {#if posting}
+        ...posting
+    {/if}
+    <form
+            method="POST"
+            action="?/submit_comment"
+            use:enhance={() => {
+            posting = true;
+            return async ({update, result}) => {
+                await update();
+                posting = false;
+                let res = result.data;
+                if (res.success) {
+                    toasts.toast = newToast("You have successfully created a comment ~~!");
+                } else {
+                    toasts.toast = newToast("Error creating a comment: " + res.message, ToastType.Error);
+                }
+            };
+        }}
+    >
+        <input type="hidden" name="commentable_id" value={feed_item.id}/>
+        <input type="hidden" name="commentable_type" value={feed_item.class_name}/>
+        <Textarea name="body" placeholder="I was thinking..."/>
+        <div class="flex justify-center pt-2">
+            <Button type="submit" className=" bg-lime-200 ">*~Submit Comment~*</Button>
+        </div>
+    </form>
+</div>

--- a/web/src/lib/components/posts/SubmitComment.svelte
+++ b/web/src/lib/components/posts/SubmitComment.svelte
@@ -3,7 +3,6 @@
     import {Button} from "$lib/components/ui/button";
     import {Textarea} from "$lib/components/ui/textarea";
     import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
-    import {invalidateAll} from "$app/navigation";
 
     let {feed_item} = $props();
 

--- a/web/src/lib/components/ui/button/button.svelte
+++ b/web/src/lib/components/ui/button/button.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { Button as ButtonPrimitive } from "bits-ui";
+	import { type Events, type Props, buttonVariants } from "./index.js";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = Props;
+	type $$Events = Events;
+
+	let className: $$Props["class"] = undefined;
+	export let variant: $$Props["variant"] = "default";
+	export let size: $$Props["size"] = "default";
+	export let builders: $$Props["builders"] = [];
+	export { className as class };
+</script>
+
+<ButtonPrimitive.Root
+	{builders}
+	class={cn(buttonVariants({ variant, size, className }))}
+	type="button"
+	{...$$restProps}
+	on:click
+	on:keydown
+>
+	<slot />
+</ButtonPrimitive.Root>

--- a/web/src/lib/components/ui/button/index.ts
+++ b/web/src/lib/components/ui/button/index.ts
@@ -1,0 +1,49 @@
+import { type VariantProps, tv } from "tailwind-variants";
+import type { Button as ButtonPrimitive } from "bits-ui";
+import Root from "./button.svelte";
+
+const buttonVariants = tv({
+	base: "ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+	variants: {
+		variant: {
+			default: "bg-primary text-primary-foreground hover:bg-primary/90",
+			destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+			outline:
+				"border-input bg-background hover:bg-accent hover:text-accent-foreground border",
+			secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+			ghost: "hover:bg-accent hover:text-accent-foreground",
+			link: "text-primary underline-offset-4 hover:underline",
+		},
+		size: {
+			default: "h-10 px-4 py-2",
+			sm: "h-9 rounded-md px-3",
+			lg: "h-11 rounded-md px-8",
+			icon: "h-10 w-10",
+		},
+	},
+	defaultVariants: {
+		variant: "default",
+		size: "default",
+	},
+});
+
+type Variant = VariantProps<typeof buttonVariants>["variant"];
+type Size = VariantProps<typeof buttonVariants>["size"];
+
+type Props = ButtonPrimitive.Props & {
+	variant?: Variant;
+	size?: Size;
+};
+
+type Events = ButtonPrimitive.Events;
+
+export {
+	Root,
+	type Props,
+	type Events,
+	//
+	Root as Button,
+	type Props as ButtonProps,
+	type Events as ButtonEvents,
+	buttonVariants,
+};

--- a/web/src/lib/components/ui/collapsible/collapsible-content.svelte
+++ b/web/src/lib/components/ui/collapsible/collapsible-content.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+	import { slide } from "svelte/transition";
+
+	type $$Props = CollapsiblePrimitive.ContentProps;
+
+	export let transition: $$Props["transition"] = slide;
+	export let transitionConfig: $$Props["transitionConfig"] = {
+		duration: 150,
+	};
+</script>
+
+<CollapsiblePrimitive.Content {transition} {transitionConfig} {...$$restProps}>
+	<slot />
+</CollapsiblePrimitive.Content>

--- a/web/src/lib/components/ui/collapsible/index.ts
+++ b/web/src/lib/components/ui/collapsible/index.ts
@@ -1,0 +1,15 @@
+import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+import Content from "./collapsible-content.svelte";
+
+const Root = CollapsiblePrimitive.Root;
+const Trigger = CollapsiblePrimitive.Trigger;
+
+export {
+	Root,
+	Content,
+	Trigger,
+	//
+	Root as Collapsible,
+	Content as CollapsibleContent,
+	Trigger as CollapsibleTrigger,
+};

--- a/web/src/lib/components/ui/textarea/index.ts
+++ b/web/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,28 @@
+import Root from "./textarea.svelte";
+
+type FormTextareaEvent<T extends Event = Event> = T & {
+	currentTarget: EventTarget & HTMLTextAreaElement;
+};
+
+type TextareaEvents = {
+	blur: FormTextareaEvent<FocusEvent>;
+	change: FormTextareaEvent<Event>;
+	click: FormTextareaEvent<MouseEvent>;
+	focus: FormTextareaEvent<FocusEvent>;
+	keydown: FormTextareaEvent<KeyboardEvent>;
+	keypress: FormTextareaEvent<KeyboardEvent>;
+	keyup: FormTextareaEvent<KeyboardEvent>;
+	mouseover: FormTextareaEvent<MouseEvent>;
+	mouseenter: FormTextareaEvent<MouseEvent>;
+	mouseleave: FormTextareaEvent<MouseEvent>;
+	paste: FormTextareaEvent<ClipboardEvent>;
+	input: FormTextareaEvent<InputEvent>;
+};
+
+export {
+	Root,
+	//
+	Root as Textarea,
+	type TextareaEvents,
+	type FormTextareaEvent,
+};

--- a/web/src/lib/components/ui/textarea/textarea.svelte
+++ b/web/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { HTMLTextareaAttributes } from "svelte/elements";
+	import type { TextareaEvents } from "./index.js";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = HTMLTextareaAttributes;
+	type $$Events = TextareaEvents;
+
+	let className: $$Props["class"] = undefined;
+	export let value: $$Props["value"] = undefined;
+	export { className as class };
+
+	// Workaround for https://github.com/sveltejs/svelte/issues/9305
+	// Fixed in Svelte 5, but not backported to 4.x.
+	export let readonly: $$Props["readonly"] = undefined;
+</script>
+
+<textarea
+	class={cn(
+		"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:value
+	{readonly}
+	on:blur
+	on:change
+	on:click
+	on:focus
+	on:keydown
+	on:keypress
+	on:keyup
+	on:mouseover
+	on:mouseenter
+	on:mouseleave
+	on:paste
+	on:input
+	{...$$restProps}
+></textarea>

--- a/web/src/lib/components/users/PendingFriendRequest.svelte
+++ b/web/src/lib/components/users/PendingFriendRequest.svelte
@@ -5,7 +5,7 @@
     import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
     import FormButton from "$lib/components/form/FormButton.svelte";
     import Form from "$lib/components/form/Form.svelte";
-    import {rails_datetime_pretty} from "$lib/utils/dates.svelte";
+    import {rails_date_pretty} from "$lib/utils/dates.svelte";
     import {goto} from "$app/navigation";
 
     let {pending_friend} = $props();

--- a/web/src/lib/state/friends_map.svelte.ts
+++ b/web/src/lib/state/friends_map.svelte.ts
@@ -1,0 +1,3 @@
+export let friends_map = $state({
+    friends_map: {},
+})

--- a/web/src/lib/utils/dates.svelte.ts
+++ b/web/src/lib/utils/dates.svelte.ts
@@ -26,7 +26,12 @@ export function rails_datetime_moment(raw_date: string) {
     return moment(raw_date, moment.ISO_8601);
 }
 
-export function rails_datetime_pretty(raw_date: string) {
+export function rails_date_pretty(raw_date: string) {
     const moment_datetime = rails_datetime_moment(raw_date);
     return moment_datetime.format('MMM D, YYYY');
+}
+
+export function rails_datetime_pretty(raw_date: string) {
+    const moment_datetime = rails_datetime_moment(raw_date);
+    return moment_datetime.format('MMM D, YYYY h:mm:ss a');
 }

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -32,7 +32,7 @@
                 console.log('not okay fm ');
                 console.log('error getting friends_map ' + res);
             }
-        }
+        };
         let fetch_notifs = async () => {
             const response = await fetch('/api/fetch_notifications', {
                 method: 'GET',
@@ -55,9 +55,10 @@
             } else {
                 console.log('error getting notifications ' + res);
             }
-        }
+        };
+        fetch_friends_map();
         fetch_notifs();
-            const interval = setInterval(() => {
+        const interval = setInterval(() => {
                 fetch_friends_map();
                 fetch_notifs();
             }, 1000 * 60 * 5); // 5 minutes
@@ -69,7 +70,10 @@
         }
     );
 
+    $inspect(friends_map.friends_map);
+
 </script>
+
 
 <div class="app">
     <Header/>

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -5,6 +5,7 @@
     import Toast from "$lib/components/Toast.svelte";
     import { current_user, isSignedIn } from '$lib/state/current_user.svelte.js';
     import { notifs } from '$lib/state/notifications.svelte';
+    import { friends_map } from "$lib/state/friends_map.svelte";
     import {onMount} from "svelte";
     import BannerNotifications from "$lib/components/notifications/BannerNotifications.svelte";
 
@@ -15,6 +16,23 @@
     // every 10 seconds, poll notifications
     onMount( () => {
 
+        // TODO: switch to SSE instead of polling
+        let fetch_friends_map = async () => {
+            const response = await fetch('/api/friends_map', {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+            const res = await response.json();
+            if (res['res']) {
+                console.log('ok fm');
+                friends_map.friends_map = res['res'];
+            } else {
+                console.log('not okay fm ');
+                console.log('error getting friends_map ' + res);
+            }
+        }
         let fetch_notifs = async () => {
             const response = await fetch('/api/fetch_notifications', {
                 method: 'GET',
@@ -40,6 +58,7 @@
         }
         fetch_notifs();
             const interval = setInterval(() => {
+                fetch_friends_map();
                 fetch_notifs();
             }, 1000 * 60 * 5); // 5 minutes
 

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -30,7 +30,7 @@
                 friends_map.friends_map = res['res'];
             } else {
                 console.log('not okay fm ');
-                console.log('error getting friends_map ' + res);
+                console.log('error getting friends_map ' + res['error']);
             }
         };
         let fetch_notifs = async () => {
@@ -53,7 +53,7 @@
                 );
                 notifs.notifs = notif_map;
             } else {
-                console.log('error getting notifications ' + res);
+                console.log('error getting notifications ' + res['error']);
             }
         };
         fetch_friends_map();

--- a/web/src/routes/(app)/events/[id]/+page.server.js
+++ b/web/src/routes/(app)/events/[id]/+page.server.js
@@ -1,6 +1,6 @@
 import * as api from '$lib/api_calls/api.svelte';
 
-export async function load({ cookies, params }) {
+export async function load({cookies, params}) {
 
     const jwt = cookies.get('jwt');
     const my_user_id = cookies.get('user_id');
@@ -33,5 +33,19 @@ export const actions = {
         );
 
         return response;
-    }
+    },
+    submit_comment: async ({cookies, request}) => {
+        const data = await request.formData();
+        const jwt = cookies.get('jwt');
+
+        return await api.post(
+            'comments',
+            {
+                body: data.get('body'),
+                commentable_id: data.get('commentable_id'),
+                commentable_type: data.get('commentable_type'),
+            },
+            jwt,
+        );
+    },
 }

--- a/web/src/routes/(app)/events/[id]/+page.svelte
+++ b/web/src/routes/(app)/events/[id]/+page.svelte
@@ -99,6 +99,5 @@
         </div>
 
         <SubmitComment feed_item={event}/>
-
     </div>
 </div>

--- a/web/src/routes/(app)/events/[id]/+page.svelte
+++ b/web/src/routes/(app)/events/[id]/+page.svelte
@@ -4,16 +4,30 @@
     import EventCard from "$lib/components/posts/EventCard.svelte";
     import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
     import {goto} from "$app/navigation";
+    import {MessageCircleMore} from "@lucide/svelte";
+    import SubmitComment from "$lib/components/posts/SubmitComment.svelte";
+    import Comment from "$lib/components/posts/Comment.svelte";
 
     let {data} = $props();
     // let user = data.user;
     let my_user_id = data.my_user_id;
-    let event = data.event;
-
-    let rsvp = event.current_user_rsvp;
 
 
     let creating = $state(false);
+
+    // Svelte pitfall.  Page updates are not triggered by load data prop change!!
+    // This is the workaround
+    let event = $state(data.event);
+    $effect(() => {
+        event = data.event;
+    })
+
+    let comments = $derived(event.comments);
+
+    let num_comments = $derived(comments.length);
+
+    let rsvp = $derived(event.current_user_rsvp);
+
 
 </script>
 
@@ -72,5 +86,19 @@
                 {/each}
             </div>
         </div>
+    </div>
+    <div>
+        <div class="flex">
+            {num_comments} Comments
+            <MessageCircleMore/>
+        </div>
+        <div>
+            {#each comments as comment}
+                <Comment {comment}/>
+            {/each}
+        </div>
+
+        <SubmitComment feed_item={event}/>
+
     </div>
 </div>

--- a/web/src/routes/(app)/posts/+page.server.js
+++ b/web/src/routes/(app)/posts/+page.server.js
@@ -1,9 +1,10 @@
-import { getPosts } from '$lib/api_calls/posts.svelte.js';
-import { getEvents, process_dates } from '$lib/api_calls/events.svelte.js';
-import { readable_backend_date } from '$lib/utils/dates.svelte';
+import {getPosts} from '$lib/api_calls/posts.svelte.js';
+import {getEvents, process_dates} from '$lib/api_calls/events.svelte.js';
+import {readable_backend_date} from '$lib/utils/dates.svelte';
 import {redirect} from "@sveltejs/kit";
 import {RecommendationStatus} from "$lib/enums.js";
-import { VITE_API_URL } from '$env/static/private';
+import {VITE_API_URL} from '$env/static/private';
+import * as api from "$lib/api_calls/api.svelte";
 
 
 let root_url = VITE_API_URL
@@ -61,6 +62,24 @@ export const actions = {
         //TODO: Success toast
 
         redirect(302, '/posts')
+    },
+    submit_comment: async ({cookies, request}) => {
+        const data = await request.formData();
+        const jwt = cookies.get('jwt');
+
+        const response = await api.post(
+            'comments',
+            {
+                body: data.get('body'),
+                commentable_id: data.get('commentable_id'),
+                commentable_type: data.get('commentable_type'),
+            },
+            jwt,
+        );
+
+        return response;
+
+
     }
 }
 

--- a/web/src/routes/(app)/posts/+page.server.js
+++ b/web/src/routes/(app)/posts/+page.server.js
@@ -23,6 +23,7 @@ export async function load({locals, cookies}) {
         events_with_dates_headers = process_dates(events);
     }
 
+
     return {
         posts: posts,
         events: events_with_dates_headers,

--- a/web/src/routes/(app)/posts/+page.server.js
+++ b/web/src/routes/(app)/posts/+page.server.js
@@ -79,8 +79,6 @@ export const actions = {
         );
 
         return response;
-
-
     }
 }
 

--- a/web/src/routes/(app)/posts/+page.server.js
+++ b/web/src/routes/(app)/posts/+page.server.js
@@ -22,6 +22,7 @@ export async function load({locals, cookies}) {
     } else {
         events_with_dates_headers = process_dates(events);
     }
+
     return {
         posts: posts,
         events: events_with_dates_headers,

--- a/web/src/routes/(app)/posts/+page.svelte
+++ b/web/src/routes/(app)/posts/+page.svelte
@@ -5,36 +5,42 @@
     import FeedItem from "$lib/components/posts/FeedItem.svelte";
     import DateHeader from "$lib/components/posts/DateHeader.svelte";
     import EventFeedItem from "$lib/components/posts/EventFeedItem.svelte";
+    import Link from "$lib/components/text/Link.svelte";
 
-    let { data } = $props();
+    let {data} = $props();
 
 </script>
 
-
 <div>
-    <LinkButton color="yellow" url="/recommendations/create">&#10133; Recommendation</LinkButton>
-    <LinkButton color="orange" url="/events/create">&#10133; Event</LinkButton>
-    <LinkButton color="blue" url="/posts/create">&#10133; Post</LinkButton>
-</div>
+    <div class="flex justify-center bg-lime-200 border-1 border-gray-800 rounded-sm font-bold p-2 mb-2">
+        <Link url="/friends">Add friends!!</Link>
+    </div>
 
-<H1>Posts</H1>
+    <div>
+        <LinkButton color="yellow" url="/recommendations/create">&#10133; Recommendation</LinkButton>
+        <LinkButton color="orange" url="/events/create">&#10133; Event</LinkButton>
+        <LinkButton color="blue" url="/posts/create">&#10133; Post</LinkButton>
+    </div>
 
-<div class="grid grid-cols-3">
-<div class="col-span-2 flex flex-col">
-    <H2>the feed</H2>
-    {#each data.posts as feed_item}
-        <FeedItem feed_item={feed_item} />
-    {/each}
+    <H1>Posts</H1>
 
-</div>
-    <div class="flex flex-col">
-        <H2>Events</H2>
-        {#each data.events as event_item}
-            {#if !!event_item['date_header']}
-                <DateHeader event_item={event_item} />
-            {:else}
-                <EventFeedItem event_item={event_item}/>
-            {/if}
-        {/each}
+    <div class="grid grid-cols-3">
+        <div class="col-span-2 flex flex-col">
+            <H2>the feed</H2>
+            {#each data.posts as feed_item}
+                <FeedItem feed_item={feed_item}/>
+            {/each}
+
+        </div>
+        <div class="flex flex-col">
+            <H2>Events</H2>
+            {#each data.events as event_item}
+                {#if !!event_item['date_header']}
+                    <DateHeader event_item={event_item}/>
+                {:else}
+                    <EventFeedItem event_item={event_item}/>
+                {/if}
+            {/each}
+        </div>
     </div>
 </div>

--- a/web/src/routes/(app)/posts/[id]/+page.server.ts
+++ b/web/src/routes/(app)/posts/[id]/+page.server.ts
@@ -13,6 +13,8 @@ export async function load({cookies, params}) {
     // TODO: Will crash if backend not running
     let res = await getPost(jwt, post_id);
 
+    console.log("posts/id load reloaded")
+    
     return {
         post: res['res'],
         my_user_id: my_user_id,

--- a/web/src/routes/(app)/posts/[id]/+page.server.ts
+++ b/web/src/routes/(app)/posts/[id]/+page.server.ts
@@ -1,5 +1,7 @@
 import * as api from '$lib/api_calls/api.svelte';
 import {getPost} from '$lib/api_calls/posts.svelte';
+import {RecommendationStatus} from "$lib/enums";
+import {redirect} from "@sveltejs/kit";
 
 
 export async function load({cookies, params}) {
@@ -14,5 +16,22 @@ export async function load({cookies, params}) {
     return {
         post: res['res'],
         my_user_id: my_user_id,
+    }
+}
+
+export const actions = {
+    submit_comment: async ({cookies, request}) => {
+        const data = await request.formData();
+        const jwt = cookies.get('jwt');
+
+        return await api.post(
+            'comments',
+            {
+                body: data.get('body'),
+                commentable_id: data.get('commentable_id'),
+                commentable_type: data.get('commentable_type'),
+            },
+            jwt,
+        );
     }
 }

--- a/web/src/routes/(app)/posts/[id]/+page.svelte
+++ b/web/src/routes/(app)/posts/[id]/+page.svelte
@@ -1,26 +1,23 @@
 <script lang="ts">
     import LinkButton from "$lib/components/text/LinkButton.svelte";
-    import EventCard from "$lib/components/posts/EventCard.svelte";
-    import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
-    import {goto} from "$app/navigation";
     import PostCard from "$lib/components/posts/PostCard.svelte";
     import {MessageCircleMore} from "@lucide/svelte";
     import Comment from "$lib/components/posts/Comment.svelte";
-    import {Button} from "$lib/components/ui/button";
-    import {Textarea} from "$lib/components/ui/textarea";
     import SubmitComment from "$lib/components/posts/SubmitComment.svelte";
 
     let {data} = $props();
-    // let user = data.user;
     let my_user_id = data.my_user_id;
-    let post = data.post;
 
-    // let rsvp = event.current_user_rsvp;
+    // Svelte pitfall.  Page updates are not triggered by load data prop change!!
+    // This is the workaround
+    let post = $state(data.post);
+    $effect(() => {
+        post = data.post;
+    })
 
+    let comments = $derived(post.comments);
 
-    // let creating = $state(false);
-
-    let num_comments = post.comments?.length;
+    let num_comments = $derived(comments.length);
 
 
 </script>
@@ -42,7 +39,7 @@
             <MessageCircleMore/>
         </div>
         <div>
-            {#each post.comments as comment}
+            {#each comments as comment}
                 <Comment {comment}/>
             {/each}
         </div>

--- a/web/src/routes/(app)/posts/[id]/+page.svelte
+++ b/web/src/routes/(app)/posts/[id]/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
-    import {enhance} from '$app/forms';
     import LinkButton from "$lib/components/text/LinkButton.svelte";
     import EventCard from "$lib/components/posts/EventCard.svelte";
     import {newToast, toasts, ToastType} from "$lib/state/toast.svelte";
     import {goto} from "$app/navigation";
     import PostCard from "$lib/components/posts/PostCard.svelte";
+    import {MessageCircleMore} from "@lucide/svelte";
+    import Comment from "$lib/components/posts/Comment.svelte";
+    import {Button} from "$lib/components/ui/button";
+    import {Textarea} from "$lib/components/ui/textarea";
+    import SubmitComment from "$lib/components/posts/SubmitComment.svelte";
 
     let {data} = $props();
     // let user = data.user;
@@ -16,6 +20,7 @@
 
     // let creating = $state(false);
 
+    let num_comments = post.comments?.length;
 
 
 </script>
@@ -29,7 +34,22 @@
 
         </div>
     {/if}
-    <PostCard feed_item={post} />
+    <PostCard feed_item={post}/>
+
+    <div>
+        <div class="flex">
+            {num_comments} Comments
+            <MessageCircleMore/>
+        </div>
+        <div>
+            {#each post.comments as comment}
+                <Comment {comment}/>
+            {/each}
+        </div>
+
+        <SubmitComment feed_item={post}/>
+
+    </div>
 
 
 </div>

--- a/web/src/routes/(app)/recommendations/[id]/+page.server.js
+++ b/web/src/routes/(app)/recommendations/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import {getRecommendation} from "$lib/api_calls/recommendations.svelte.js";
 import {getUser} from '$lib/api_calls/users.svelte.js';
+import * as api from "$lib/api_calls/api.svelte.js";
 
 export async function load({cookies, params}) {
 
@@ -16,4 +17,21 @@ export async function load({cookies, params}) {
         user: user['res'],
         my_user_id: my_user_id,
     }
+}
+
+export const actions = {
+    submit_comment: async ({cookies, request}) => {
+        const data = await request.formData();
+        const jwt = cookies.get('jwt');
+
+        return await api.post(
+            'comments',
+            {
+                body: data.get('body'),
+                commentable_id: data.get('commentable_id'),
+                commentable_type: data.get('commentable_type'),
+            },
+            jwt,
+        );
+    },
 }

--- a/web/src/routes/(app)/recommendations/[id]/+page.svelte
+++ b/web/src/routes/(app)/recommendations/[id]/+page.svelte
@@ -4,10 +4,23 @@
     import Card from "$lib/components/Card.svelte";
     import PlusCircle from "$lib/components/posts/PlusCircle.svelte";
     import LinkButton from "$lib/components/text/LinkButton.svelte";
+    import {MessageCircleMore} from "@lucide/svelte";
+    import SubmitComment from "$lib/components/posts/SubmitComment.svelte";
+    import Comment from "$lib/components/posts/Comment.svelte";
 
     let {data} = $props();
     let user = data.user;
-    let recommendation = data.recommendation;
+
+    // Svelte pitfall.  Page updates are not triggered by load data prop change!!
+    // This is the workaround
+    let recommendation = $state(data.recommendation);
+    $effect(() => {
+        recommendation = data.recommendation;
+    })
+
+    let comments = $derived(recommendation.comments);
+
+    let num_comments = $derived(comments.length);
 
 
 </script>
@@ -28,4 +41,18 @@
         <p>Who recommended? {recommendation.who_recommended}</p>
         <p>Added: {recommendation.create_date_string}</p>
     </Card>
+
+    <div>
+        <div class="flex">
+            {num_comments} Comments
+            <MessageCircleMore/>
+        </div>
+        <div>
+            {#each comments as comment}
+                <Comment {comment}/>
+            {/each}
+        </div>
+
+        <SubmitComment feed_item={recommendation}/>
+    </div>
 </div>

--- a/web/src/routes/api/friends_map/+server.js
+++ b/web/src/routes/api/friends_map/+server.js
@@ -1,0 +1,16 @@
+import * as api from '$lib/api_calls/api.svelte';
+import {json} from '@sveltejs/kit';
+
+export async function GET({request, cookies}) {
+    const jwt = cookies.get('jwt');
+
+    // This gives us a lookup map of { user_id: user }
+    const friends_map_response = await api.get(
+        'friendships/friends_map',
+        jwt,
+    );
+
+    2 + 5;
+
+    return json(friends_map_response);
+}


### PR DESCRIPTION
# Feature

Display comments in the feed

<img width="760" alt="image" src="https://github.com/user-attachments/assets/6437966b-5907-4c8d-bcb3-bcf52c25e7bc" />

- I show the first comment if one exists
- clicking it or "10 comments" expands the comments

<img width="702" alt="image" src="https://github.com/user-attachments/assets/4e0bfefc-66ca-4fbf-acfc-749234089878" />


---

You can now make and view comments on events, recommendations, and posts

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/4c2c04d7-82e9-4bc7-84c2-18fe549a87d6" />

<img width="1123" alt="image" src="https://github.com/user-attachments/assets/5c4e1111-8be2-4992-9baa-11bfd8405235" />

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/ad9ab8ee-9df7-42a6-83ea-fe801be7c3bc" />


A toast will appear

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/adccd140-93fa-459f-a03a-894d4f57d143" />


---

## Svelte gotcha


Page does not automatically update if ``` let {data} = $props()``` is updated, even if the page's load function is called.
I needed to add an effect to trigger the page update.  Here's how:

![image](https://github.com/user-attachments/assets/04c68e63-65e5-4914-8943-e897b4ef6445)

See this commit [how to trigger page updates based on load data change in svelte -- pitfall](https://github.com/sllewely/recommendations2025/commit/7e384b2ce75a46c04f28575f5aea1e411db77157)
