### PR TITLE
fix: check for auth token when computing signed in status

### DIFF
--- a/web/src/lib/components/Header.svelte
+++ b/web/src/lib/components/Header.svelte
@@ -5,7 +5,7 @@
 
     let user_id = current_user.id;
 
-    let signed_in = $derived(current_user && current_user.id !== '');
+    let signed_in = $derived(current_user && current_user.auth_token !== '');
 
     let log_out = async () => {
         const response = await fetch('/api/log_out', {


### PR DESCRIPTION
Current code checks `current_user.id`. Updated to check `current_user.auth_token` instead when computing signed in status.

Fixes #14 