### PR TITLE
Remove extra https in link URL

### DIFF
--- a/backend/celeryapp/app/mailers/friendship_mailer.rb
+++ b/backend/celeryapp/app/mailers/friendship_mailer.rb
@@ -1,7 +1,7 @@
 class FriendshipMailer < ApplicationMailer
   def pending_friend_request
     @user = params[:user]
-    @url = 'https://https://bumblebeans.social/friends'
+    @url = 'https://bumblebeans.social/friends'
     mail(to: [@user.email], subject: '[Bumblebeans.social] You have a new friend request!')
   end
 


### PR DESCRIPTION
There was an extra `https://` in the new friend request email link. This PR fixes that. :) Cheers!
~ Andie