### PR TITLE
File upload

### DIFF
--- a/backend/celeryapp/.idea/celeryapp.iml
+++ b/backend/celeryapp/.idea/celeryapp.iml
@@ -41,6 +41,12 @@
     <orderEntry type="library" scope="PROVIDED" name="activesupport (v8.0.2, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.7, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="authentication-zero (v4.0.3, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="aws-eventstream (v1.4.0, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="aws-partitions (v1.1110.0, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="aws-sdk-core (v3.225.0, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="aws-sdk-kms (v1.102.0, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="aws-sdk-s3 (v1.189.0, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="aws-sigv4 (v1.12.0, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="base64 (v0.3.0, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bcrypt (v3.1.20, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="benchmark (v0.4.1, RVM: ruby-3.2.2) [gem]" level="application" />
@@ -70,6 +76,7 @@
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.7, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="io-console (v0.8.0, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="irb (v1.15.2, RVM: ruby-3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="jmespath (v1.6.2, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="launchy (v3.1.1, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="letter_opener (v1.10.0, RVM: ruby-3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="logger (v1.7.0, RVM: ruby-3.2.2) [gem]" level="application" />

--- a/backend/celeryapp/Gemfile
+++ b/backend/celeryapp/Gemfile
@@ -40,6 +40,9 @@ gem "bootsnap", require: false
 # emails
 gem 'resend'
 
+# s3 for photos
+gem 'aws-sdk-s3'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/backend/celeryapp/Gemfile.lock
+++ b/backend/celeryapp/Gemfile.lock
@@ -75,6 +75,24 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     authentication-zero (4.0.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1110.0)
+    aws-sdk-core (3.225.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.102.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.189.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.1)
@@ -122,6 +140,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     launchy (3.1.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -251,6 +270,7 @@ PLATFORMS
 
 DEPENDENCIES
   authentication-zero (~> 4.0)
+  aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap
   database_cleaner

--- a/backend/celeryapp/app/controllers/images_controller.rb
+++ b/backend/celeryapp/app/controllers/images_controller.rb
@@ -1,6 +1,8 @@
 class ImagesController < ApplicationController
 
   def profile_picture
-    
+
+    render json: {}, status: :ok
+
   end
 end

--- a/backend/celeryapp/app/controllers/images_controller.rb
+++ b/backend/celeryapp/app/controllers/images_controller.rb
@@ -1,0 +1,6 @@
+class ImagesController < ApplicationController
+
+  def profile_picture
+    
+  end
+end

--- a/backend/celeryapp/app/controllers/images_controller.rb
+++ b/backend/celeryapp/app/controllers/images_controller.rb
@@ -1,6 +1,10 @@
 class ImagesController < ApplicationController
+  include S3ImageHelper
 
   def profile_picture
+
+    file = params[:file]
+    res = S3ImageHelper.put_object("profile_pictures/#{current_user.id}", file.read)
 
     render json: {}, status: :ok
 

--- a/backend/celeryapp/app/helpers/s3_image_helper.rb
+++ b/backend/celeryapp/app/helpers/s3_image_helper.rb
@@ -1,0 +1,35 @@
+require 'aws-sdk-s3'
+
+module S3ImageHelper
+  BUCKET = "bb-profile-image-dev"
+  URL_EXPIRES_IN = 3600
+  CONTENT_TYPE = "image/jpeg"
+
+  def self.s3_client
+    credentials = Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
+    Aws::S3::Client.new(
+      region: "us-east-2",
+      credentials: credentials
+    )
+  end
+
+  def self.put_object(object_key, file)
+    s3_client.put_object(
+      bucket: BUCKET,
+      key: object_key,
+      body: file,
+      content_type: CONTENT_TYPE
+    )
+  end
+
+  def self.get_presigned_url(object_key)
+    signer = Aws::S3::Presigner.new(client: s3_client)
+
+    signer.presigned_url(:put_object,
+                         bucket: BUCKET,
+                         key: object_key,
+                         expires_in: URL_EXPIRES_IN,
+                         content_type: CONTENT_TYPE
+    )
+  end
+end

--- a/backend/celeryapp/app/helpers/s3_image_helper.rb
+++ b/backend/celeryapp/app/helpers/s3_image_helper.rb
@@ -29,6 +29,8 @@ module S3ImageHelper
     )
   end
 
+  # This... could be used to upload files directly from the frontend without sending to the backend
+  # but I got a 403 Forbidden error with no further details when I tried
   def self.get_presigned_url(object_key)
     signer = Aws::S3::Presigner.new(client: s3_client)
 

--- a/backend/celeryapp/app/helpers/s3_image_helper.rb
+++ b/backend/celeryapp/app/helpers/s3_image_helper.rb
@@ -22,6 +22,13 @@ module S3ImageHelper
     )
   end
 
+  def self.get_object(object_key)
+    s3_client.get_object(
+      bucket: BUCKET,
+      key: object_key
+    )
+  end
+
   def self.get_presigned_url(object_key)
     signer = Aws::S3::Presigner.new(client: s3_client)
 

--- a/backend/celeryapp/config/environments/development.rb
+++ b/backend/celeryapp/config/environments/development.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.cache_store = :memory_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/backend/celeryapp/config/environments/production.rb
+++ b/backend/celeryapp/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/backend/celeryapp/config/routes.rb
+++ b/backend/celeryapp/config/routes.rb
@@ -27,5 +27,10 @@ Rails.application.routes.draw do
   resources :friend_requests
   resources :notifications
   resources :comments
+  resources :images do
+    collection do
+      post 'profile_picture'
+    end
+  end
 
 end

--- a/backend/celeryapp/config/storage.yml
+++ b/backend/celeryapp/config/storage.yml
@@ -6,13 +6,13 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+  # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+  amazon:
+    service: S3
+    access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+    secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+    region: us-east-2
+    bucket: bb-profile-image-dev
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/backend/celeryapp/spec/requests/images_spec.rb
+++ b/backend/celeryapp/spec/requests/images_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Images", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/web/src/routes/(app)/users/edit/+page.svelte
+++ b/web/src/routes/(app)/users/edit/+page.svelte
@@ -16,6 +16,9 @@
 
 <div>
 	<p>#TODO page needs a fun background!!</p>
+	<img
+		src={"https://bb-profile-image-dev.s3.us-east-2.amazonaws.com/profile_pictures/" + user.id}
+	/>
 	<H1>{user.name}</H1>
 	<Link url="">photo upload</Link>
 

--- a/web/src/routes/(app)/users/edit/+page.svelte
+++ b/web/src/routes/(app)/users/edit/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import H1 from "$lib/components/text/H1.svelte";
 	import UserForm from "./UserForm.svelte";
+	import Link from "$lib/components/text/Link.svelte";
 
 	let { data, form } = $props();
 	let creating = $state(false);
@@ -16,6 +17,7 @@
 <div>
 	<p>#TODO page needs a fun background!!</p>
 	<H1>{user.name}</H1>
+	<Link url="">photo upload</Link>
 
 	<div>
 		<UserForm form_data={data.form} {tags} />

--- a/web/src/routes/(app)/users/edit/profile_picture/+page.server.ts
+++ b/web/src/routes/(app)/users/edit/profile_picture/+page.server.ts
@@ -1,0 +1,42 @@
+import { getUser } from "$lib/api_calls/users.svelte.js";
+import * as api from "$lib/api_calls/api.svelte.js";
+import type { PageServerLoad } from "./$types.js";
+import { superValidate } from "sveltekit-superforms";
+import { imageFormSchema } from "./schema";
+import { zod } from "sveltekit-superforms/adapters";
+import { fail } from "@sveltejs/kit";
+
+export const load: PageServerLoad = async ({ cookies, params }) => {
+	let user_id = cookies.get("user_id");
+	const jwt = cookies.get("jwt");
+	let user = await getUser(jwt, user_id);
+	const user_obj = user["res"];
+
+	return {
+		form_data: await superValidate(zod(imageFormSchema)),
+	};
+};
+
+export const actions = {
+	update_user: async ({ cookies, request }) => {
+		const form = await superValidate(request, zod(imageFormSchema));
+
+		if (!form.valid) {
+			// Return { form } and things will just work.
+			return fail(400, { form });
+		}
+
+		2 + 5;
+		const user_id = cookies.get("user_id");
+		const jwt = cookies.get("jwt");
+		const tags = (form.data.string_tags ?? "").split(",");
+
+		return await api.patch(
+			"images/profile_picture",
+			{
+				image: form.data.image,
+			},
+			jwt,
+		);
+	},
+};

--- a/web/src/routes/(app)/users/edit/profile_picture/+page.server.ts
+++ b/web/src/routes/(app)/users/edit/profile_picture/+page.server.ts
@@ -5,6 +5,7 @@ import { superValidate } from "sveltekit-superforms";
 import { imageFormSchema } from "./schema";
 import { zod } from "sveltekit-superforms/adapters";
 import { fail } from "@sveltejs/kit";
+import { VITE_API_URL } from "$env/static/private";
 
 export const load: PageServerLoad = async ({ cookies, params }) => {
 	let user_id = cookies.get("user_id");
@@ -29,14 +30,26 @@ export const actions = {
 		2 + 5;
 		const user_id = cookies.get("user_id");
 		const jwt = cookies.get("jwt");
-		const tags = (form.data.string_tags ?? "").split(",");
 
-		return await api.patch(
-			"images/profile_picture",
-			{
-				image: form.data.image,
+		const formData = new FormData();
+		formData.append("file", form.data.image);
+
+		const response = await fetch(VITE_API_URL + "images/profile_picture", {
+			method: "POST",
+			headers: {
+				Authorization: "Token " + jwt,
 			},
-			jwt,
-		);
+			body: formData,
+		});
+
+		return response;
+
+		// return await api.post(
+		// 	"images/profile_picture",
+		// 	{
+		// 		image: form.data.image,
+		// 	},
+		// 	jwt,
+		// );
 	},
 };

--- a/web/src/routes/(app)/users/edit/profile_picture/+page.server.ts
+++ b/web/src/routes/(app)/users/edit/profile_picture/+page.server.ts
@@ -43,13 +43,5 @@ export const actions = {
 		});
 
 		return response;
-
-		// return await api.post(
-		// 	"images/profile_picture",
-		// 	{
-		// 		image: form.data.image,
-		// 	},
-		// 	jwt,
-		// );
 	},
 };

--- a/web/src/routes/(app)/users/edit/profile_picture/+page.svelte
+++ b/web/src/routes/(app)/users/edit/profile_picture/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { enhance } from "$app/forms";
+	import { newToast, ToastType } from "$lib/state/toast.svelte";
+	import { Input } from "$lib/components/ui/input";
+	import * as Form from "$lib/components/ui/form";
+	import { imageFormSchema, type ImageSchema } from "./schema";
+	import { type SuperValidated, type Infer, superForm } from "sveltekit-superforms";
+	import { zodClient } from "sveltekit-superforms/adapters";
+
+	interface Props {
+		data: { form_data: SuperValidated<Infer<ImageSchema>> };
+	}
+
+	let { data }: Props = $props();
+	const form = superForm(data.form_data, {
+		validators: zodClient(imageFormSchema),
+	});
+	const { form: formData } = form;
+
+	let creating = $state(false);
+
+	let avatar, fileinput;
+	let upload_photo = async (file) => {
+		const response = await fetch("/api/upload_profile_picture", {
+			method: "POST",
+			body: JSON.stringify({ file: file }),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+	};
+	const onFileSelected = (e: Event) => {
+		let image = e.target.files[0];
+		// let reader = new FileReader();
+		// reader.readAsDataURL(image);
+		upload_photo(image);
+		// reader.onload = (e) => {
+		// 	avatar = e.target.result;
+		// };
+	};
+</script>
+
+<div>
+	<form
+		id="user_form"
+		enctype="multipart/form-data"
+		method="POST"
+		action="?/update_user"
+		use:enhance={() => {
+			creating = true;
+			return async ({ update, result }) => {
+				await update();
+				creating = false;
+				let res = result.data;
+				if (res.success) {
+					newToast("You have successfully updated your user");
+				} else {
+					newToast("Error updating " + res.message, ToastType.Error);
+				}
+			};
+		}}
+	>
+		<Form.Field {form} name="image">
+			<Form.Control let:attrs>
+				<Form.Label>photo</Form.Label>
+				<Input type="file" {...attrs} bind:value={$formData.image} />
+			</Form.Control>
+			<Form.Description>Upload a profile photo.</Form.Description>
+			<Form.FieldErrors />
+		</Form.Field>
+
+		<div class="flex flex-col space-y-2">
+			<Form.Button
+				on:click={() => {
+					console.log("click!!");
+				}}
+			>
+				Update
+			</Form.Button>
+		</div>
+	</form>
+</div>

--- a/web/src/routes/(app)/users/edit/profile_picture/+page.svelte
+++ b/web/src/routes/(app)/users/edit/profile_picture/+page.svelte
@@ -51,12 +51,12 @@
 			return async ({ update, result }) => {
 				await update();
 				creating = false;
-				let res = result.data;
-				if (res.success) {
-					newToast("You have successfully updated your user");
-				} else {
-					newToast("Error updating " + res.message, ToastType.Error);
-				}
+				// let res = result.data;
+				// if (res.success) {
+				// 	newToast("You have successfully updated your user");
+				// } else {
+				// 	newToast("Error updating " + res.message, ToastType.Error);
+				// }
 			};
 		}}
 	>

--- a/web/src/routes/(app)/users/edit/profile_picture/+page.svelte
+++ b/web/src/routes/(app)/users/edit/profile_picture/+page.svelte
@@ -18,26 +18,6 @@
 	const { form: formData } = form;
 
 	let creating = $state(false);
-
-	let avatar, fileinput;
-	let upload_photo = async (file) => {
-		const response = await fetch("/api/upload_profile_picture", {
-			method: "POST",
-			body: JSON.stringify({ file: file }),
-			headers: {
-				"Content-Type": "application/json",
-			},
-		});
-	};
-	const onFileSelected = (e: Event) => {
-		let image = e.target.files[0];
-		// let reader = new FileReader();
-		// reader.readAsDataURL(image);
-		upload_photo(image);
-		// reader.onload = (e) => {
-		// 	avatar = e.target.result;
-		// };
-	};
 </script>
 
 <div>

--- a/web/src/routes/(app)/users/edit/profile_picture/schema.ts
+++ b/web/src/routes/(app)/users/edit/profile_picture/schema.ts
@@ -3,14 +3,6 @@ import { z } from "zod";
 const MAX_FILE_SIZE = 5000000;
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 
-// export const IMAGE_SCHEMA = z
-// 	.any()
-// 	.refine(
-// 		(file) =>
-// 			["image/png", "image/jpeg", "image/jpg", "image/svg+xml", "image/gif"].includes(file.type),
-// 		{ message: "Invalid image file type" },
-// 	);
-
 export const imageFormSchema = z.object({
 	image: z
 		.any()

--- a/web/src/routes/(app)/users/edit/profile_picture/schema.ts
+++ b/web/src/routes/(app)/users/edit/profile_picture/schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const MAX_FILE_SIZE = 5000000;
+const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
+
+// export const IMAGE_SCHEMA = z
+// 	.any()
+// 	.refine(
+// 		(file) =>
+// 			["image/png", "image/jpeg", "image/jpg", "image/svg+xml", "image/gif"].includes(file.type),
+// 		{ message: "Invalid image file type" },
+// 	);
+
+export const imageFormSchema = z.object({
+	image: z
+		.any()
+		.refine((file) => file?.size <= MAX_FILE_SIZE, `Max image size is 5MB.`)
+		.refine(
+			(file) => ACCEPTED_IMAGE_TYPES.includes(file?.type),
+			"Only .jpg, .jpeg, .png and .webp formats are supported.",
+		),
+});
+
+export type ImageSchema = typeof imageFormSchema;


### PR DESCRIPTION
# Feature

A user can upload a profile picture!

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/b6920ab6-71ce-4904-adc1-57a7e0e032a3" />

You must go to http://localhost:5173/users/edit/profile_picture

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/4825c615-0a75-438e-bf84-15b7196bfe6d" />


<img width="1303" alt="image" src="https://github.com/user-attachments/assets/dcd436ac-b73c-4e66-9555-487b12a9f248" />


Add the image and click update.

It's saved in aws s3


This feature is pretty thoroughly incomplete, but it's caused me a bunch of agony trying to get this to work.  I'm excited to get back to more features and higher velocity work & am feeling majorly unblocked just by making this flow possible

## Next up:

so much work!
- verify it's an image being uploaded
- display a profile picture next to usernames throughout the app
- display a fallback if a profile picture doesn't exist
- image is displayed as a round circle... or do we like squares??
- image is rendered as a specific size
- separate dev and prod environments
- lol upload page errors even on success

stretch goals:
- user can crop image
- upload in specific ratio / size / multiple sizes for different displays
- consider using Wasabi instead of aws (I hear it's cheaper??)
- monitoring to ensure I don't end up with too many images & requests costing me lots of $$$ :(