### PR TITLE
firefox bug with calendar date picker in events forrm -- not really fixed

### DIFF
--- a/web/src/routes/events/EventsForm.svelte
+++ b/web/src/routes/events/EventsForm.svelte
@@ -105,6 +105,10 @@
 					</Popover.Root>
 					<input hidden value={$formData.start_date} name="start_date" />
 				</Form.Control>
+				<Form.Description
+					>Omg there's something wrong with this date picker in firefox. Please just keep clicking
+					for now until it opens :(.
+				</Form.Description>
 				<Form.FieldErrors />
 			</Form.Field>
 			<Form.Field {form} name="start_time">


### PR DESCRIPTION
# Feature

Updated svelte shadcn popover but I think it's a firefox problem -- totally responsive on chrome