### PR TITLE
Events Posts Recommendations have uuid pk

### DIFF
--- a/backend/celeryapp/app/controllers/events_controller.rb
+++ b/backend/celeryapp/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  skip_before_action :authenticate, only: [:public_events]
+  skip_before_action :authenticate, only: [:public_events, :show]
 
   def index
     @events = Event.includes(:rsvps).where('start_date_time > ?', DateTime.now).order(start_date_time: :asc)

--- a/backend/celeryapp/app/controllers/events_controller.rb
+++ b/backend/celeryapp/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  skip_before_action :authenticate, only: [:public_events, :show]
+  skip_before_action :authenticate, only: [:public_events]
 
   def index
     @events = Event.includes(:rsvps).where('start_date_time > ?', DateTime.now).order(start_date_time: :asc)

--- a/backend/celeryapp/app/models/post.rb
+++ b/backend/celeryapp/app/models/post.rb
@@ -1,12 +1,8 @@
 class Post < ApplicationRecord
   include DateHelper
 
-  has_many :post_recommendations
-  has_many :recommendations, through: :post_recommendations
   belongs_to :user
   has_many :comments, as: :commentable
-
-  accepts_nested_attributes_for :recommendations
 
   validates :post_title, presence: true
 
@@ -14,7 +10,7 @@ class Post < ApplicationRecord
 
   def attributes
     super.merge(
-      { recommendations: recommendations,
+      {
         user: user.public_attributes,
         class_name: 'Post',
         create_date_string: get_date_string(created_at),

--- a/backend/celeryapp/app/models/post_recommendation.rb
+++ b/backend/celeryapp/app/models/post_recommendation.rb
@@ -1,4 +1,0 @@
-class PostRecommendation < ApplicationRecord
-  belongs_to :post
-  belongs_to :recommendation
-end

--- a/backend/celeryapp/app/models/recommendation.rb
+++ b/backend/celeryapp/app/models/recommendation.rb
@@ -1,7 +1,5 @@
 class Recommendation < ApplicationRecord
   include DateHelper
-  has_many :post_recommendations
-  has_many :posts, through: :post_recommendations
   belongs_to :user
   has_many :comments, as: :commentable
 

--- a/backend/celeryapp/db/migrate/20250819193143_point_to_event_uuid.rb
+++ b/backend/celeryapp/db/migrate/20250819193143_point_to_event_uuid.rb
@@ -1,0 +1,20 @@
+class PointToEventUuid < ActiveRecord::Migration[8.0]
+  def up
+    # Only RSVPs point to event id
+    remove_foreign_key Rsvp.table_name, column: :event_id
+
+    rename_column :events, :id, :numeric_id
+    rename_column :events, :uuid, :id
+
+    change_pk(:events)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'This migration cannot be reverted because column renaming needs to happen first.'
+  end
+
+  def change_pk(table)
+    execute "ALTER TABLE #{table} DROP CONSTRAINT #{table}_pkey;"
+    execute "ALTER TABLE #{table} ADD PRIMARY KEY (id);"
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819193644_event_uuid_fk.rb
+++ b/backend/celeryapp/db/migrate/20250819193644_event_uuid_fk.rb
@@ -1,0 +1,11 @@
+class EventUuidFk < ActiveRecord::Migration[8.0]
+  def up
+    rename_column Rsvp.table_name, :event_id, :numeric_event_id
+    add_column Rsvp.table_name, :event_id, :uuid
+  end
+
+  def down
+    remove_column Rsvp.table_name, :event_id
+    rename_column Rsvp.table_name, :numeric_event_id, :event_id
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819194141_populate_event_uuid_in_rsvp.rb
+++ b/backend/celeryapp/db/migrate/20250819194141_populate_event_uuid_in_rsvp.rb
@@ -1,0 +1,17 @@
+class PopulateEventUuidInRsvp < ActiveRecord::Migration[8.0]
+  def up
+    # map for reassigning ids
+    events = Event.all.each_with_object({}) do |event, hash|
+      hash[event.numeric_id] = event.id
+    end
+
+    Rsvp.all.each do |rsvp|
+      rsvp.update(event_id: events[rsvp.numeric_event_id])
+    end
+    add_foreign_key Rsvp.table_name, :events, column: :event_id, on_delete: :cascade
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'This migration cannot be reverted because column renaming needs to happen first.'
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819194907_nullable_numeric_event_id_in_rsvp.rb
+++ b/backend/celeryapp/db/migrate/20250819194907_nullable_numeric_event_id_in_rsvp.rb
@@ -1,0 +1,5 @@
+class NullableNumericEventIdInRsvp < ActiveRecord::Migration[8.0]
+  def change
+    change_column Rsvp.table_name, :numeric_event_id, :integer, null: true
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819195034_nullable_event_numeric_id.rb
+++ b/backend/celeryapp/db/migrate/20250819195034_nullable_event_numeric_id.rb
@@ -1,0 +1,5 @@
+class NullableEventNumericId < ActiveRecord::Migration[8.0]
+  def change
+    change_column :events, :numeric_id, :bigint, default: 0, null: true
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819195148_rsvp_index.rb
+++ b/backend/celeryapp/db/migrate/20250819195148_rsvp_index.rb
@@ -1,6 +1,6 @@
 class RsvpIndex < ActiveRecord::Migration[8.0]
   def change
     add_index :rsvps, [:user_id, :event_id], unique: true
-    add_index :rsvps, [:event_id], unique: true
+    add_index :rsvps, [:event_id]
   end
 end

--- a/backend/celeryapp/db/migrate/20250819195148_rsvp_index.rb
+++ b/backend/celeryapp/db/migrate/20250819195148_rsvp_index.rb
@@ -1,0 +1,6 @@
+class RsvpIndex < ActiveRecord::Migration[8.0]
+  def change
+    add_index :rsvps, [:user_id, :event_id], unique: true
+    add_index :rsvps, [:event_id], unique: true
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819203123_recommendation_posts_have_uuid_pk.rb
+++ b/backend/celeryapp/db/migrate/20250819203123_recommendation_posts_have_uuid_pk.rb
@@ -1,0 +1,20 @@
+class RecommendationPostsHaveUuidPk < ActiveRecord::Migration[8.0]
+  def up
+    rename_column :posts, :id, :numeric_id
+    rename_column :posts, :uuid, :id
+    rename_column :recommendations, :id, :numeric_id
+    rename_column :recommendations, :uuid, :id
+
+    change_pk(:posts)
+    change_pk(:recommendations)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'This migration cannot be reverted because column renaming needs to happen first.'
+  end
+
+  def change_pk(table)
+    execute "ALTER TABLE #{table} DROP CONSTRAINT #{table}_pkey;"
+    execute "ALTER TABLE #{table} ADD PRIMARY KEY (id);"
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819203635_commentable_uuid.rb
+++ b/backend/celeryapp/db/migrate/20250819203635_commentable_uuid.rb
@@ -1,0 +1,11 @@
+class CommentableUuid < ActiveRecord::Migration[8.0]
+  def up
+    rename_column Comment.table_name, :commentable_id, :numeric_commentable_id
+    add_column Comment.table_name, :commentable_id, :uuid
+  end
+
+  def down
+    remove_column Comment.table_name, :commentable_id
+    rename_column Comment.table_name, :numeric_commentable_id, :commentable_id
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819203751_populate_commentable_uuid_for_comments.rb
+++ b/backend/celeryapp/db/migrate/20250819203751_populate_commentable_uuid_for_comments.rb
@@ -1,0 +1,28 @@
+class PopulateCommentableUuidForComments < ActiveRecord::Migration[8.0]
+  def up
+    # map for reassigning ids
+    posts = Post.all.each_with_object({}) do |posts, hash|
+      hash[posts.numeric_id] = posts.id
+    end
+    recommendations = Recommendation.all.each_with_object({}) do |recommendations, hash|
+      hash[recommendations.numeric_id] = recommendations.id
+    end
+    events = Event.all.each_with_object({}) do |event, hash|
+      hash[event.numeric_id] = event.id
+    end
+
+    Comment.all.each do |comment|
+      if comment.commentable_type == 'Post'
+        comment.update(commentable_id: posts[comment.numeric_commentable_id])
+      elsif comment.commentable_type == 'Recommendation'
+        comment.update(commentable_id: recommendations[comment.numeric_commentable_id])
+      else
+        comment.update(commentable_id: events[comment.numeric_commentable_id])
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'This migration cannot be reverted because column renaming needs to happen first.'
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819204233_commentable_id_is_nullable.rb
+++ b/backend/celeryapp/db/migrate/20250819204233_commentable_id_is_nullable.rb
@@ -1,0 +1,9 @@
+class CommentableIdIsNullable < ActiveRecord::Migration[8.0]
+  def change
+    change_column Comment.table_name, :numeric_commentable_id, :integer, null: true
+
+    # nullabe sequential id for recommendations and posts
+    change_column :recommendations, :numeric_id, :bigint, default: 0, null: true
+    change_column :posts, :numeric_id, :bigint, default: 0, null: true
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819204422_commentable_index.rb
+++ b/backend/celeryapp/db/migrate/20250819204422_commentable_index.rb
@@ -1,0 +1,5 @@
+class CommentableIndex < ActiveRecord::Migration[8.0]
+  def change
+    add_index :comments, [:commentable_id, :commentable_type]
+  end
+end

--- a/backend/celeryapp/db/migrate/20250819205155_drop_table_post_recommendation.rb
+++ b/backend/celeryapp/db/migrate/20250819205155_drop_table_post_recommendation.rb
@@ -1,0 +1,5 @@
+class DropTablePostRecommendation < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :post_recommendations
+  end
+end

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_203751) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_204233) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_203751) do
   create_table "comments", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "numeric_commentable_id", null: false
+    t.integer "numeric_commentable_id"
     t.string "commentable_type", null: false
     t.integer "numeric_user_id"
     t.text "body", null: false
@@ -118,7 +118,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_203751) do
   end
 
   create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "numeric_id", default: -> { "nextval('posts_id_seq'::regclass)" }, null: false
+    t.bigint "numeric_id", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "post_title"
@@ -130,7 +130,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_203751) do
   end
 
   create_table "recommendations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "numeric_id", default: -> { "nextval('recommendations_id_seq'::regclass)" }, null: false
+    t.bigint "numeric_id", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -156,7 +156,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_195148) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
     t.uuid "event_id"
-    t.index ["event_id"], name: "index_rsvps_on_event_id", unique: true
+    t.index ["event_id"], name: "index_rsvps_on_event_id"
     t.index ["numeric_event_id"], name: "index_rsvps_on_numeric_event_id"
     t.index ["numeric_user_id", "numeric_event_id"], name: "index_rsvps_on_numeric_user_id_and_numeric_event_id", unique: true
     t.index ["numeric_user_id"], name: "index_rsvps_on_numeric_user_id"

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_195148) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_203123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -116,19 +116,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_195148) do
     t.index ["uuid"], name: "index_post_recommendations_on_uuid", unique: true
   end
 
-  create_table "posts", force: :cascade do |t|
+  create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "numeric_id", default: -> { "nextval('posts_id_seq'::regclass)" }, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "post_title"
     t.text "content"
     t.integer "numeric_user_id"
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
+    t.index ["id"], name: "index_posts_on_id", unique: true
     t.index ["numeric_user_id"], name: "index_posts_on_numeric_user_id"
-    t.index ["uuid"], name: "index_posts_on_uuid", unique: true
   end
 
-  create_table "recommendations", force: :cascade do |t|
+  create_table "recommendations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "numeric_id", default: -> { "nextval('recommendations_id_seq'::regclass)" }, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
@@ -139,12 +140,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_195148) do
     t.integer "rating", default: 0
     t.integer "numeric_user_id"
     t.string "url"
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
+    t.index ["id"], name: "index_recommendations_on_id", unique: true
     t.index ["numeric_user_id", "title", "media_type"], name: "idx_on_numeric_user_id_title_media_type_02ab1e85f5", unique: true
     t.index ["numeric_user_id"], name: "index_recommendations_on_numeric_user_id"
     t.index ["user_id", "title", "media_type"], name: "index_recommendations_on_user_id_and_title_and_media_type", unique: true
-    t.index ["uuid"], name: "index_recommendations_on_uuid", unique: true
   end
 
   create_table "rsvps", force: :cascade do |t|

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_193644) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_195148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -30,7 +30,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_193644) do
   end
 
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "numeric_id", default: -> { "nextval('events_id_seq'::regclass)" }, null: false
+    t.bigint "numeric_id", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
@@ -151,14 +151,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_193644) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "numeric_user_id"
-    t.bigint "numeric_event_id", null: false
+    t.integer "numeric_event_id"
     t.integer "status", default: 0
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
     t.uuid "event_id"
+    t.index ["event_id"], name: "index_rsvps_on_event_id", unique: true
     t.index ["numeric_event_id"], name: "index_rsvps_on_numeric_event_id"
     t.index ["numeric_user_id", "numeric_event_id"], name: "index_rsvps_on_numeric_user_id_and_numeric_event_id", unique: true
     t.index ["numeric_user_id"], name: "index_rsvps_on_numeric_user_id"
+    t.index ["user_id", "event_id"], name: "index_rsvps_on_user_id_and_event_id", unique: true
     t.index ["user_id", "numeric_event_id"], name: "index_rsvps_on_user_id_and_numeric_event_id", unique: true
     t.index ["uuid"], name: "index_rsvps_on_uuid", unique: true
   end
@@ -231,6 +233,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_193644) do
   add_foreign_key "notifications", "users", on_delete: :cascade
   add_foreign_key "posts", "users", on_delete: :cascade
   add_foreign_key "recommendations", "users", on_delete: :cascade
+  add_foreign_key "rsvps", "events", on_delete: :cascade
   add_foreign_key "rsvps", "users", on_delete: :cascade
   add_foreign_key "sessions", "users", on_delete: :cascade
   add_foreign_key "user_statuses", "users", on_delete: :cascade

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_18_210436) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_193644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -29,7 +29,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_210436) do
     t.index ["uuid"], name: "index_comments_on_uuid", unique: true
   end
 
-  create_table "events", force: :cascade do |t|
+  create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "numeric_id", default: -> { "nextval('events_id_seq'::regclass)" }, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title", null: false
@@ -41,14 +42,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_210436) do
     t.integer "numeric_user_id"
     t.datetime "end_date_time"
     t.boolean "is_public", default: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
     t.index ["end_date_time"], name: "index_events_on_end_date_time"
     t.index ["event_type"], name: "index_events_on_event_type"
+    t.index ["id"], name: "index_events_on_id", unique: true
     t.index ["is_public"], name: "index_events_on_is_public"
     t.index ["numeric_user_id"], name: "index_events_on_numeric_user_id"
     t.index ["start_date_time"], name: "index_events_on_start_date_time"
-    t.index ["uuid"], name: "index_events_on_uuid", unique: true
   end
 
   create_table "friend_codes", force: :cascade do |t|
@@ -151,14 +151,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_210436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "numeric_user_id"
-    t.bigint "event_id", null: false
+    t.bigint "numeric_event_id", null: false
     t.integer "status", default: 0
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
-    t.index ["event_id"], name: "index_rsvps_on_event_id"
-    t.index ["numeric_user_id", "event_id"], name: "index_rsvps_on_numeric_user_id_and_event_id", unique: true
+    t.uuid "event_id"
+    t.index ["numeric_event_id"], name: "index_rsvps_on_numeric_event_id"
+    t.index ["numeric_user_id", "numeric_event_id"], name: "index_rsvps_on_numeric_user_id_and_numeric_event_id", unique: true
     t.index ["numeric_user_id"], name: "index_rsvps_on_numeric_user_id"
-    t.index ["user_id", "event_id"], name: "index_rsvps_on_user_id_and_event_id", unique: true
+    t.index ["user_id", "numeric_event_id"], name: "index_rsvps_on_user_id_and_numeric_event_id", unique: true
     t.index ["uuid"], name: "index_rsvps_on_uuid", unique: true
   end
 
@@ -230,7 +231,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_210436) do
   add_foreign_key "notifications", "users", on_delete: :cascade
   add_foreign_key "posts", "users", on_delete: :cascade
   add_foreign_key "recommendations", "users", on_delete: :cascade
-  add_foreign_key "rsvps", "events"
   add_foreign_key "rsvps", "users", on_delete: :cascade
   add_foreign_key "sessions", "users", on_delete: :cascade
   add_foreign_key "user_statuses", "users", on_delete: :cascade

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_204422) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_205155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -107,15 +107,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_204422) do
     t.uuid "user_id"
     t.index ["numeric_user_id"], name: "index_notifications_on_numeric_user_id"
     t.index ["uuid"], name: "index_notifications_on_uuid", unique: true
-  end
-
-  create_table "post_recommendations", force: :cascade do |t|
-    t.integer "post_id"
-    t.integer "recommendation_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
-    t.index ["uuid"], name: "index_post_recommendations_on_uuid", unique: true
   end
 
   create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_203123) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_203751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -18,13 +18,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_203123) do
   create_table "comments", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "commentable_id", null: false
+    t.bigint "numeric_commentable_id", null: false
     t.string "commentable_type", null: false
     t.integer "numeric_user_id"
     t.text "body", null: false
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
-    t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
+    t.uuid "commentable_id"
+    t.index ["numeric_commentable_id", "commentable_type"], name: "index_comments_on_numeric_commentable_id_and_commentable_type"
     t.index ["numeric_user_id"], name: "index_comments_on_numeric_user_id"
     t.index ["uuid"], name: "index_comments_on_uuid", unique: true
   end

--- a/backend/celeryapp/db/schema.rb
+++ b/backend/celeryapp/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_204233) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_204422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -25,6 +25,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_204233) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "user_id"
     t.uuid "commentable_id"
+    t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
     t.index ["numeric_commentable_id", "commentable_type"], name: "index_comments_on_numeric_commentable_id_and_commentable_type"
     t.index ["numeric_user_id"], name: "index_comments_on_numeric_user_id"
     t.index ["uuid"], name: "index_comments_on_uuid", unique: true

--- a/backend/celeryapp/spec/factories/post_recommendations.rb
+++ b/backend/celeryapp/spec/factories/post_recommendations.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :post_recommendation do
-    
-  end
-end


### PR DESCRIPTION
# Feature

all backend

Events post recommendations have a string uuid for their primary key id -- this will enable events to be shared by a link when not logged in (and not insecurely expose all events by sequentially scraping).  I had to migrate all 3 because Comments use a polymorphic "Commentable_id" to point to all 3 types -- but if we want, it opens the door for public posts and recommendations too

