### PR TITLE
fix: header state not updating on first login without refresh

### DIFF
--- a/web/src/lib/components/Header.svelte
+++ b/web/src/lib/components/Header.svelte
@@ -4,8 +4,6 @@
 	import { setPendingToast, ToastType } from "$lib/state/toast.svelte";
 	import { Settings } from "@lucide/svelte";
 
-	let user_id = current_user.id;
-
 	let signed_in = $state(false);
 
 	$effect(() => {
@@ -35,7 +33,9 @@
 			<ul class="list-reset flex justify-center flex-wrap text-xs md:text-sm gap-3">
 				{#if signed_in}
 					<li><a href="/posts" class="text-gray-400 hover:text-white">Posts</a></li>
-					<li><a href="/users/{user_id}" class="text-gray-400 hover:text-white">My profile</a></li>
+					<li>
+						<a href="/users/{current_user.id}" class="text-gray-400 hover:text-white">My profile</a>
+					</li>
 				{/if}
 				<!--				<li><a href="/events/map" class="text-gray-400 hover:text-white">Map!</a></li>-->
 				<li><a href="/events" class="text-gray-400 hover:text-white">Events</a></li>
@@ -80,8 +80,9 @@
 				<ul class="list-reset flex justify-center flex-wrap text-xs md:text-sm gap-3">
 					<li><a href="/friends" class="text-gray-400 hover:text-white">Friends</a></li>
 					<li>
-						<a href="/recommendations/users/{user_id}" class="text-gray-400 hover:text-white"
-							>Saved Recommendations</a
+						<a
+							href="/recommendations/users/{current_user.id}"
+							class="text-gray-400 hover:text-white">Saved Recommendations</a
 						>
 					</li>
 				</ul>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -14,7 +14,11 @@
 
 	let { children, data } = $props();
 
-	current_user.id = data.current_user_id;
+	$effect(() => {
+		if (data.current_user_id) {
+			current_user.id = data.current_user_id;
+		}
+	});
 
 	// every 10 seconds, poll notifications
 	onMount(() => {

--- a/web/src/routes/posts/+page.server.ts
+++ b/web/src/routes/posts/+page.server.ts
@@ -7,12 +7,12 @@ import { redirect } from "@sveltejs/kit";
 import { createComment, type CommentPayload } from "$lib/api_calls/comments.svelte.js";
 import { formDataToGeneric } from "$lib/api_calls/utils";
 
-export const load = withAuth(async ({ jwt }: LoadAuthContext) => {
+export const load = withAuth(async ({ jwt, user_id }: LoadAuthContext) => {
 	const [postsResponse, eventsResponse] = await Promise.all([getPosts(jwt), getEvents(jwt)]);
-
 	return {
 		posts_response: postsResponse.success ? (postsResponse.res ?? {}) : {},
 		events: eventsResponse["res"],
+		current_user_id: user_id,
 	};
 });
 

--- a/web/src/routes/sign_in/SigninForm.svelte
+++ b/web/src/routes/sign_in/SigninForm.svelte
@@ -39,8 +39,7 @@
 				creating = false;
 				let res = result.data;
 				if (res.success) {
-					current_user.auth_token = res["auth_token"];
-					current_user.id = res["user_id"];
+					current_user.id = res["res"]["my_user_id"];
 					setPendingToast("You have successfully signed in!", ToastType.Success);
 					goto("/posts");
 				} else {


### PR DESCRIPTION
- Remove static user_id variable in Header component and use reactive current_user.id directly
- Wrap user assignment in () in layout to ensure reactivity to server data
- Pass current_user_id from posts page server load function
- Update signin form to use correct response structure for user ID

This ensures the header properly shows authenticated state and user-specific links immediately after login without requiring a page refresh.