### PR TITLE
fix: prevent auth state corruption when creating recommendations

### DIFF
--- a/web/src/routes/recommendations/RecommendationForm.svelte
+++ b/web/src/routes/recommendations/RecommendationForm.svelte
@@ -83,9 +83,7 @@
 					creating = false;
 					let res = result.data;
 					if (res.success) {
-						current_user.auth_token = res["auth_token"];
-						current_user.id = res["user_id"];
-						newToast("You have successfully created a recommendation");
+						newToast("You have successfully created a recommendation", ToastType.Success);
 					} else {
 						newToast("Error creating recommendation: " + res.message, ToastType.Error);
 					}


### PR DESCRIPTION
- Remove incorrect auth token and user ID updates from recommendation form success handler
- Creating recommendations should not modify user authentication state
- Fix issue where users appeared "logged out" after creating a recommendation
- Add proper toast type (ToastType.Success) for consistency

This resolves the bug where the header would lose authentication state after successfully creating a recommendation, causing the UI to appear as if the user was logged out even though their session remained valid.