### PR TITLE
destroying a post destroys the feed item.

### DIFF
--- a/backend/celeryapp/app/models/event.rb
+++ b/backend/celeryapp/app/models/event.rb
@@ -3,8 +3,8 @@ class Event < ApplicationRecord
   belongs_to :user
   # create scopes for each rsvp status
   has_many :rsvps
-  has_many :comments, as: :commentable
-  has_one :feed_item, as: :feedable
+  has_many :comments, as: :commentable, dependent: :destroy
+  has_one :feed_item, as: :feedable, dependent: :destroy
 
   before_save :ensure_end_time
 

--- a/backend/celeryapp/app/models/post.rb
+++ b/backend/celeryapp/app/models/post.rb
@@ -2,8 +2,8 @@ class Post < ApplicationRecord
   include DateHelper
 
   belongs_to :user
-  has_many :comments, as: :commentable
-  has_one :feed_item, as: :feedable
+  has_many :comments, as: :commentable, dependent: :destroy
+  has_one :feed_item, as: :feedable, dependent: :destroy
 
   validates :post_title, presence: true
 

--- a/backend/celeryapp/app/models/recommendation.rb
+++ b/backend/celeryapp/app/models/recommendation.rb
@@ -1,8 +1,8 @@
 class Recommendation < ApplicationRecord
   include DateHelper
   belongs_to :user
-  has_many :comments, as: :commentable
-  has_one :feed_item, as: :feedable
+  has_many :comments, as: :commentable, dependent: :destroy
+  has_one :feed_item, as: :feedable, dependent: :destroy
 
   enum :status, [:interested, :watching, :recommend]
 

--- a/backend/celeryapp/spec/requests/posts_spec.rb
+++ b/backend/celeryapp/spec/requests/posts_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe "Posts", type: :request do
       expect(res['post_title']).to eq("new fav book")
     end
 
-    # it 'posts must have a title' do
-    #   post "/posts", params: { content: "I love it a lot, you should read it" }, headers: @headers
-    #
-    #   expect(response).to have_http_status(:unprocessable_content)
-    #   res = JSON.parse(response.body)
-    #   expect(res['exception']).to eq("#<ActiveRecord::RecordInvalid: Validation failed: Post title can't be blank>")
-    # end
-
     it 'posts must have a title' do
       post "/posts", params: { content: "I love it a lot, you should read it" }, headers: @headers
 
@@ -38,31 +30,6 @@ RSpec.describe "Posts", type: :request do
       res = JSON.parse(response.body)
       expect(res['error']).to eq("post_title: can't be blank")
     end
-
-    # it 'creates a new post with a recommendation' do
-    #   post "/posts", params: { post_title: "new fav book", content: "I love it a lot, you should read it", recommendations_attributes: [title: "Annihilation", notes: "A book I like"] }, headers: @headers
-    #
-    #   expect(response).to have_http_status(:created)
-    #   res = JSON.parse(response.body)
-    #   expect(res['id']).to_not be_nil
-    #   expect(res['post_title']).to eq("new fav book")
-    #   expect(res['recommendations'].first['title']).to eq('Annihilation')
-    # end
-
-    # it 'creates a new post with a recommendation with rating' do
-    #   post "/posts", params: { post_title: "new fav book", content: "I love it a lot, you should read it", recommendations_attributes: [title: "Annihilation", notes: "A book I like", rating: 5, status: 'recommend', media_type: 'book'] }, headers: @headers
-    #
-    #   expect(response).to have_http_status(:created)
-    #   res = JSON.parse(response.body)
-    #   expect(res['id']).to_not be_nil
-    #   expect(res['post_title']).to eq("new fav book")
-    #   rec_res = res['recommendations'].first
-    #   expect(rec_res['title']).to eq('Annihilation')
-    #   expect(rec_res['rating']).to eq(5)
-    #   expect(rec_res['status']).to eq('recommend')
-    #   expect(rec_res['media_type']).to eq('book')
-    #   expect(rec_res['notes']).to eq('A book I like')
-    # end
   end
 
   describe "GET /posts" do
@@ -298,6 +265,20 @@ RSpec.describe "Posts", type: :request do
 
       expect(response).to have_http_status(:ok)
       deleted_post = Post.find_by(id: p.id)
+      expect(deleted_post).to be_nil
+    end
+
+    it 'deleting my post deletes the feed item' do
+      post "/posts", params: { post_title: "new fav book", content: "I love it a lot, you should read it" }, headers: @headers
+      res = JSON.parse(response.body)
+      post_id = res['id']
+
+      delete "/posts/#{post_id}", params: {}, headers: @headers
+
+      expect(FeedItem.where(feedable_id: post_id, feedable_type: "Post")).to be_empty
+
+      expect(response).to have_http_status(:ok)
+      deleted_post = Post.find_by(id: post_id)
       expect(deleted_post).to be_nil
     end
 


### PR DESCRIPTION
# Feature

also the feed item is destroyed with an event or recommendation is deleted too

This bug was causing bumblebeans to 500 on /posts!

<img width="1121" height="388" alt="image" src="https://github.com/user-attachments/assets/3b95a506-e2dc-47f0-a519-fd700c130dea" />
